### PR TITLE
Create messages 2

### DIFF
--- a/pipelines/pipeline/shared/message.py
+++ b/pipelines/pipeline/shared/message.py
@@ -1,0 +1,154 @@
+
+"""
+Functions to create nicely formatted and informative messages.
+"""
+from os import pipe
+from pathlib import Path
+import json
+from typing import Dict
+
+from dpytools.stores.directory.base import BaseWritableSingleDirectoryStore
+
+
+def unexpected_error(msg: str, error: Exception) -> str:
+    """
+    We've caught an unexpected error. Make a sensible message explaining
+    the problem.
+    """
+    error_type = error.__class__.__name__
+    message = f"""
+        {msg}
+
+        Error type: {error_type}
+        Error: {error}
+    """
+
+    return message
+
+
+def cant_find_schema(config_dict, error: Exception) -> str:
+    """
+    We got an error when trying to identify the schema for the pipeline-conifg.json using the
+    pipeline-config.json.
+
+    Using the config-dict and the exceptioncreate a clear and informative message about what
+    the problem is."""
+    formatted_config_dict = json.dumps(config_dict, indent=2)
+    error_type = error.__class__.__name__
+    message = f"""  
+        We got an error when trying to identify the schema for the pipeline-config.json using the pipeline-config.json.
+        
+        Pipeline-config.json: {formatted_config_dict}
+        
+        Error type: {error_type}
+        Error: {error}
+    """
+    return message
+
+
+def invalid_config(config_dict, error: Exception) -> str:
+    """
+    The pipeline config that was provided is failing to validate.
+
+    Provide suitable information so someone can find out why.
+    """
+    formatted_config_dict = json.dumps(config_dict, indent=2)
+    error_type = error.__class__.__name__
+    message = f"""
+        The pipeline config that was provided is failing to validate.
+        
+        Pipeline-config.json: {formatted_config_dict}
+
+        Error type: {error_type}
+        Error: {error}
+    """
+    return message
+
+
+def unknown_pipeline(pipeline_name: str, pipeline_options: dict) -> str:
+    """
+    We've been given a pipeline identifier that we don't recnognise. Use the name of
+    the runing pipeline and the pipeline configuration to create a meaningful message
+    explaining the problem.
+    """
+    formatted_pipeline_options = json.dumps(pipeline_options, indent=2)
+    message = f"""
+        Pipeline name is missing from the pipeline configurations.
+        
+        Pipeline: {pipeline_name}
+        Pipeline Configurations: {formatted_pipeline_options}
+    """
+    return message
+
+
+def metadata_validation_error(metadata_path, error: Exception) -> str:
+    """
+    The metadata has generated as validation error. Use the metadata and the error to create a
+    sensible message explaining the problem.
+    """
+    error_type = error.__class__.__name__
+    message = f"""
+        Metadata json file has failed validation: {metadata_path}
+        Error type: {error_type}
+        Error: {error}
+    """
+    return message
+
+
+def expected_local_file_missing(msg: str, file_path: Path, pipeline_name: str) -> str:
+    """
+    We're looking for a file on the local machine/runner and cannot find it.
+    """
+    message = f"""
+        A pipeline has encountered an issue finding a local file.
+        
+        Pipeline's name: {pipeline_name}
+        File: {file_path}
+        Message: {msg}
+    """
+    return message
+
+
+def pipeline_input_exception(pipeline_dict: Dict, store: BaseWritableSingleDirectoryStore, error: Exception):
+    """
+    Some pipeline details specifiy a file but there was an issue getting it out of the store.
+    """
+    error_type = error.__class__.__name__
+    formatted_pipeline_dict = json.dumps(pipeline_dict, indent=2)
+    message = f"""
+        File specified in pipeline details could not be retrieved from store: {store.local_path}
+        Error type: {error_type}
+        Error: {error}
+        Pipeline details dictionary: {formatted_pipeline_dict}
+    """
+    return message
+
+
+def error_in_transform(pipeline_dict, store: BaseWritableSingleDirectoryStore, error: Exception) -> str:
+    """
+    An exception was raised during the transform process.
+    """
+    error_type = error.__class__.__name__
+    formatted_pipeline_dict = json.dumps(pipeline_dict, indent=2)
+    message = f"""
+        An error occured during the transformation process for pipeline input with store: {store.local_path}
+        Error type: {error_type}
+        Error: {error}
+        Pipeline details dictionary: {formatted_pipeline_dict}
+    """
+    return message
+
+    
+def pipeline_input_sanity_check_exception(pipeline_dict, store: BaseWritableSingleDirectoryStore, error: Exception) -> str:
+    """
+    An exception was raised during the sanity checking process.
+    """
+    error_type = error.__class__.__name__
+    formatted_pipeline_dict = json.dumps(pipeline_dict, indent=2)
+    message = f"""
+        An error was raised while performing a sanity check on pipeline with given store: {store.local_path}
+        Error type: {error_type}
+        Error: {error}
+        Pipeline details dictionary: {formatted_pipeline_dict}
+    """
+    return message

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,0 +1,177 @@
+from dpytools.stores.directory.local import LocalDirectoryStore
+import pytest
+from pipelines.pipeline.shared.message import (
+    unexpected_error, 
+    cant_find_schema,
+    invalid_config,
+    unknown_pipeline,
+    metadata_validation_error,
+    expected_local_file_missing,
+    pipeline_input_exception,
+    error_in_transform,
+    pipeline_input_sanity_check_exception
+)
+
+
+def test_unexpected_error():
+    error = Exception("Some file is missing.")
+    expected_message = """
+        Something went wrong
+
+        Error type: Exception
+        Error: Some file is missing.
+    """
+
+    assert unexpected_error("Something went wrong", error) == expected_message
+
+
+def test_cant_find_scheama():
+    error = Exception("Something went wrong")
+    config_dict = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "$id": "https://raw.githubusercontent.com/ONSdigital/sandbox/initial-structure/schemas/ingress/config/v1.json"
+    }
+
+    human_readable_output = cant_find_schema(config_dict, error)
+
+    assert 'We got an error when trying to identify the schema for the pipeline-config.json using the pipeline-config.json.' in human_readable_output
+    assert 'Pipeline-config.json:' in human_readable_output
+    assert '"$schema": "http://json-schema.org/draft-04/schema#"' in human_readable_output
+    assert '"$id": "https://raw.githubusercontent.com/ONSdigital/sandbox/initial-structure/schemas/ingress/config/v1.json"' in human_readable_output
+    assert 'Error type: Exception' in human_readable_output
+    assert 'Error: Something went wrong' in human_readable_output
+    assert type(human_readable_output) == str
+
+
+def test_invalid_config():
+    error = Exception("Something went wrong")
+    config_dict = {
+        "$schema": "http://json-schema.org/invalid/schema#",
+        "$id": "https://raw.githubusercontent.com/ONSdigital/sandbox/initial-structure/schemas/ingress/config/v1.json"
+    }
+    human_readable_output = invalid_config(config_dict, error)
+    
+    assert "The pipeline config that was provided is failing to validate." in human_readable_output
+    assert "Pipeline-config.json:" in human_readable_output
+    assert '"$schema": "http://json-schema.org/invalid/schema#"' in human_readable_output
+    assert '"$id": "https://raw.githubusercontent.com/ONSdigital/sandbox/initial-structure/schemas/ingress/config/v1.json"' in human_readable_output
+    assert 'Error type: Exception' in human_readable_output
+    assert "Error: Something went wrong" in human_readable_output
+    assert type(human_readable_output) == str
+
+
+def test_unknown_pipeline():
+    
+    pipeline_name = "sdmx.default"
+    pipeline_options = {
+        "pipeline idemtifier": "pipeline123"
+    }
+
+    human_readable_output = unknown_pipeline(pipeline_name, pipeline_options)
+
+    assert 'Pipeline name is missing from the pipeline configurations.' in human_readable_output
+    assert 'Pipeline: sdmx.default' in human_readable_output
+    assert 'Pipeline Configurations:' in human_readable_output
+    assert '"pipeline idemtifier": "pipeline123"' in human_readable_output
+    assert type(human_readable_output) == str
+
+
+def test_metadata_validation_error():
+    error = Exception("Something went wrong")
+    human_readable_output = metadata_validation_error("/some_parent_dir/some_dir/metadata.json", error)
+    expected_output = """
+        Metadata json file has failed validation: /some_parent_dir/some_dir/metadata.json
+        Error type: Exception
+        Error: Something went wrong
+    """
+
+    assert human_readable_output == expected_output
+    assert type(human_readable_output) == str
+
+
+def test_expected_local_file_missing():
+    human_readable_output = expected_local_file_missing("Something went wrong", "/some_parent_dir/some_dir/some_json.json", "Pipeline123")
+    expected_output = """
+        A pipeline has encountered an issue finding a local file.
+        
+        Pipeline's name: Pipeline123
+        File: /some_parent_dir/some_dir/some_json.json
+        Message: Something went wrong
+    """
+    assert human_readable_output == expected_output
+    assert type(human_readable_output) == str
+
+
+def test_pipeline_input_exception():
+    """
+    Checks that the error message for a pipeline input exception contains 
+    the expected message text and details.
+    """
+    store_path = "tests/fixtures/test-cases/message_test_directory"
+    test_input_store = LocalDirectoryStore(store_path)
+
+    pipeline_dict = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "$id": "https://raw.githubusercontent.com/ONSdigital/sandbox/initial-structure/schemas/ingress/config/v1.json"
+    }
+
+    error = Exception("Something went wrong during the pipeline input process")
+    human_readable_output = pipeline_input_exception(pipeline_dict, test_input_store, error)
+
+    assert """File specified in pipeline details could not be retrieved from store: tests/fixtures/test-cases/message_test_directory
+        Error type: Exception
+        Error: Something went wrong during the pipeline input process""" in human_readable_output
+    assert '"$schema": "http://json-schema.org/draft-04/schema#"' in human_readable_output
+    assert '"$id": "https://raw.githubusercontent.com/ONSdigital/sandbox/initial-structure/schemas/ingress/config/v1.json"' in human_readable_output
+
+    assert type(human_readable_output) == str
+
+
+def test_error_in_transform():
+    """
+    Checks that the error message for an error in the transformation process 
+    contains the expected message text and details.
+    """
+    store_path = "tests/fixtures/test-cases/message_test_directory"
+    test_input_store = LocalDirectoryStore(store_path)
+
+    pipeline_dict = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "$id": "https://raw.githubusercontent.com/ONSdigital/sandbox/initial-structure/schemas/ingress/config/v1.json"
+    }
+
+    error = Exception("Something went wrong during the transformation process")
+    human_readable_output = error_in_transform(pipeline_dict, test_input_store, error)
+
+    assert """An error occured during the transformation process for pipeline input with store: tests/fixtures/test-cases/message_test_directory
+        Error type: Exception
+        Error: Something went wrong during the transformation process""" in human_readable_output
+    assert '"$schema": "http://json-schema.org/draft-04/schema#"' in human_readable_output
+    assert '"$id": "https://raw.githubusercontent.com/ONSdigital/sandbox/initial-structure/schemas/ingress/config/v1.json"' in human_readable_output
+
+    assert type(human_readable_output) == str
+
+
+def test_pipeline_input_sanity_check_exception():
+    """
+    Checks that the error message for an error during the sanity check of the 
+    input contains the expected message text and details.
+    """
+    store_path = "tests/fixtures/test-cases/message_test_directory"
+    test_input_store = LocalDirectoryStore(store_path)
+
+    pipeline_dict = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "$id": "https://raw.githubusercontent.com/ONSdigital/sandbox/initial-structure/schemas/ingress/config/v1.json"
+    }
+
+    error = Exception("Something went wrong during the pipeline input sanity check")
+    human_readable_output = pipeline_input_sanity_check_exception(pipeline_dict, test_input_store, error)
+
+    assert """An error was raised while performing a sanity check on pipeline with given store: tests/fixtures/test-cases/message_test_directory
+        Error type: Exception
+        Error: Something went wrong during the pipeline input sanity check""" in human_readable_output
+    assert '"$schema": "http://json-schema.org/draft-04/schema#"' in human_readable_output
+    assert '"$id": "https://raw.githubusercontent.com/ONSdigital/sandbox/initial-structure/schemas/ingress/config/v1.json"' in human_readable_output
+
+    assert type(human_readable_output) == str


### PR DESCRIPTION
### What

Adds 3 new functions for error messages and unit tests for each one checking the returned message contents.

### How to review

Check that the error messages are sensible and contain reasonable details on the errors. Check that the tests are making the right assertions/checks.

Please let me know what your thoughts are on my use of local_path in the message text. I could not think of a way to use the input store otherwise to add detail to the message, but local_path depends on `LocalDirectoryStore` which is an implementation of `BaseWritableDirectoryStore`. If I shouldn't use that here I am happy to change it.

### Who can review

Anyone.