### PR TITLE
schema path bug fix

### DIFF
--- a/dpypelines/pipeline/shared/schemas.py
+++ b/dpypelines/pipeline/shared/schemas.py
@@ -7,8 +7,12 @@ def get_config_schema_path(config: dict) -> Path:
     """
     Returns the local path to a schema from the `$id` specified in a pipeline config dictionary
     """
+    
+    # Getting the absolute path to the 'dpypelines/' directory
+    dpypelines_absolute_path = Path(__file__).parent.parent.parent.absolute()
+
     # Set the base path for the schemas
-    schema_base_path = Path("dpypelines/schemas/dataset-ingress/config").absolute()
+    schema_base_path = Path("schemas/dataset-ingress/config")
 
     # Check `$id` is in the config dictionary keys
     if "$id" not in config.keys():
@@ -23,7 +27,7 @@ def get_config_schema_path(config: dict) -> Path:
     config_schema_version = config_id_path.name
 
     # Get the local path to the schema and check it exists
-    local_schema_path = schema_base_path / config_schema_version
+    local_schema_path = dpypelines_absolute_path / schema_base_path / config_schema_version
     if not local_schema_path.exists():
         all_schema_paths = [
             os.path.join(schema_base_path, file)


### PR DESCRIPTION
###What
changed the shemas.py file to find the 'dpypelines' directory using 'Path(file).parent' and then finding schema base path relative path to 'dpypelines' directory.

###How to review
Sanity checks
Look at: https://github.com/ONSdigital/dp-data-pipelines/issues/61, and follow instruction on installing 'dp-data-pipelines' as python package and running example code, to see that no error show up. (make sure correct python interpreter is selected i.e. the python interpreter with the 'dp-data-pipelines' python package)

###Who can review
Anyone