### PR TITLE
dont reference variable after failed assignment

### DIFF
--- a/dpypelines/pipeline/dataset_ingress_v1.py
+++ b/dpypelines/pipeline/dataset_ingress_v1.py
@@ -132,10 +132,8 @@ def dataset_ingress_v1(files_dir: str):
         notify.data_engineering(
             message.unexpected_error(
                 f"""
-            Failed to get tranform details.", 
-            
-            transform_identifier: {transform_identifier}
-            transform_details" {json.dumps(all_transform_details, indent=2, default=lambda x: str(x))}
+            Failed to get transform identifier from transform details", 
+            {json.dumps(all_transform_details, indent=2, default=lambda x: str(x))}
             """, err
         ))
         raise err


### PR DESCRIPTION
### What

correcting an oversight, just a simple logical error:

- in the event we could not create the variable "transform_identifier"
- we raised an error which **included** that variable we don't have

### How to review

Sanity check

### Who can review

Anyone