### PR TITLE
add configurable notification postfix

### DIFF
--- a/dpypelines/pipeline/shared/message.py
+++ b/dpypelines/pipeline/shared/message.py
@@ -8,10 +8,7 @@ from typing import Dict
 
 from dpytools.stores.directory.base import BaseWritableSingleDirectoryStore
 
-from dpypelines.pipeline.shared.utility import enrich_online
 
-
-@enrich_online
 def unexpected_error(msg: str, error: Exception) -> str:
     """
     We've caught an unexpected error. Make a sensible message explaining
@@ -28,7 +25,6 @@ def unexpected_error(msg: str, error: Exception) -> str:
     return message
 
 
-@enrich_online
 def cant_find_schema(config_dict, error: Exception) -> str:
     """
     We got an error when trying to identify the schema for the pipeline-conifg.json using the
@@ -49,7 +45,6 @@ def cant_find_schema(config_dict, error: Exception) -> str:
     return message
 
 
-@enrich_online
 def invalid_config(config_dict, error: Exception) -> str:
     """
     The pipeline config that was provided is failing to validate.
@@ -69,7 +64,6 @@ def invalid_config(config_dict, error: Exception) -> str:
     return message
 
 
-@enrich_online
 def unknown_transform(transform_identifier: str, all_transform_details: dict) -> str:
     """
     We've been given a transform identifier that we don't recnognise. Create a
@@ -87,7 +81,6 @@ def unknown_transform(transform_identifier: str, all_transform_details: dict) ->
     return message
 
 
-@enrich_online
 def metadata_validation_error(metadata_path, error: Exception) -> str:
     """
     The metadata has generated as validation error. Use the metadata and the error to create a
@@ -102,7 +95,6 @@ def metadata_validation_error(metadata_path, error: Exception) -> str:
     return message
 
 
-@enrich_online
 def expected_local_file_missing(
     msg: str,
     file_path: Path,
@@ -125,7 +117,6 @@ def expected_local_file_missing(
     return message
 
 
-@enrich_online
 def pipeline_input_exception(
     pipeline_dict: Dict, store: BaseWritableSingleDirectoryStore, error: Exception
 ):
@@ -143,7 +134,6 @@ def pipeline_input_exception(
     return message
 
 
-@enrich_online
 def error_in_transform(
     pipeline_dict, store: BaseWritableSingleDirectoryStore, error: Exception
 ) -> str:
@@ -161,7 +151,6 @@ def error_in_transform(
     return message
 
 
-@enrich_online
 def pipeline_input_sanity_check_exception(
     pipeline_dict, store: BaseWritableSingleDirectoryStore, error: Exception
 ) -> str:

--- a/dpypelines/pipeline/shared/notification.py
+++ b/dpypelines/pipeline/shared/notification.py
@@ -49,12 +49,15 @@ class PipelineNotifier(BasePipelineNotifier):
             webhook_url is not None
         ), "Unable to find required environment variable to populate webhook_url argument"
         self.client = SlackMessenger(webhook_url)
+        self.notification_postfix = os.environ.get("NOTIFICATION_POSTFIX", "")
 
     def failure(self):
-        self.client.msg_str(":boom:")
+        msg = f":boom: {self.notification_postfix}".strip()
+        self.client.msg_str(msg)
 
     def success(self):
-        self.client.msg_str(":white_check_mark:")
+        msg = f":white_check_mark: {self.notification_postfix}".strip()
+        self.client.msg_str(msg)
 
     # TODO - remove me later
     # only present while we're using the temporary "everything worked" message

--- a/dpypelines/pipeline/shared/utility.py
+++ b/dpypelines/pipeline/shared/utility.py
@@ -1,21 +1,3 @@
-import os
-
-
-def enrich_online(message_creating_function):
-    def wrapper(*args, **kwargs):
-        msg: str = message_creating_function(*args, **kwargs)
-
-        # Get the enviormentl variable
-        enrich_message = os.environ.get("ENRICH_OUTGOING_MESSAGES", None)
-        # If there is a value stored add (enrich) message otherwise return original message
-        if enrich_message is not None:
-            return msg + " " + enrich_message
-        else:
-            return msg
-
-    return wrapper
-
-
 # devnote: not using strtobool from disutils as that
 # package is being depreciate from the standard
 # library in python >3.12

--- a/tests/pipelines/pipeline/shared/test_notification.py
+++ b/tests/pipelines/pipeline/shared/test_notification.py
@@ -1,3 +1,7 @@
+from dataclasses import dataclass
+from typing  import Optional
+from unittest.mock import MagicMock
+
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
@@ -52,3 +56,39 @@ def test_notification_raises_for_missing_webhook():
         "Unable to find required environment variable to populate webhook_url argument"
         in str(e.value)
     )
+
+
+def test_notification_custom_postfix_success():
+    """
+    Test that we can add a custom postfix to the notification message
+    for a success.
+    """
+    postfix_str = "i-might-be-a-url"
+
+    mp = MonkeyPatch()
+    mp.setenv("DISABLE_NOTIFICATIONS", "False")
+    mp.setenv("NOTIFICATION_POSTFIX", postfix_str)
+
+    notifier = PipelineNotifier("_")
+    notifier.client = MagicMock()
+    notifier.success()
+
+    notifier.client.msg_str.assert_called_once_with(f":white_check_mark: {postfix_str}")
+
+
+def test_notification_custom_postfix_success():
+    """
+    Test that we can add a custom postfix to the notification message
+    for a failure.
+    """
+    postfix_str = "i-might-be-a-url"
+
+    mp = MonkeyPatch()
+    mp.setenv("DISABLE_NOTIFICATIONS", "False")
+    mp.setenv("NOTIFICATION_POSTFIX", postfix_str)
+
+    notifier = PipelineNotifier("_")
+    notifier.client = MagicMock()
+    notifier.failure()
+
+    notifier.client.msg_str.assert_called_once_with(f":boom: {postfix_str}")

--- a/tests/pipelines/pipeline/shared/test_notification.py
+++ b/tests/pipelines/pipeline/shared/test_notification.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-from typing  import Optional
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/pipelines/pipeline/shared/test_utility.py
+++ b/tests/pipelines/pipeline/shared/test_utility.py
@@ -1,25 +1,6 @@
 import pytest
-from _pytest.monkeypatch import monkeypatch
 
-from dpypelines.pipeline.shared.utility import enrich_online, str_to_bool
-
-def test_enrich_decorator(monkeypatch):
-    """
-    Test we can control the behaviour of the enrich online decorator via an env var.
-    """
-
-    @enrich_online
-    def _foo_func() -> str:
-        return "foo"
-
-    # no env var set
-    assert _foo_func() == "foo"
-
-    # creating an enviormental variable for the test
-    monkeypatch.setenv("ENRICH_OUTGOING_MESSAGES", "boo")
-
-    # env var is set
-    assert _foo_func() == "foo" + " boo"
+from dpypelines.pipeline.shared.utility import str_to_bool
 
 
 def test_str_to_bool_valid_values():


### PR DESCRIPTION
### What

Added the ability to add a string postfix to the end of the success and fail notifications (so we can add a url at the platform level).

Have removed the enrich_online decorator, made sense when we were sending full messages, less so now.

### How to review

Sanity check,

### Who can review

Anyone.