### PR TITLE
remove confirmation to slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ If the `s3_tar_received.start()` function encounters any problems, an error will
 | DS_SLACK_WEBHOOK      |  None   | Webhook for the Data Submitters Slack channel                             |
 | PS_SLACK_WEBHOOK      |  None   | Webhook for the Publishing Support Slack channel                          |
 | DISABLE_NOTIFICATIONS |  False  | Toggle Slack notifications on or off                                      |
-| AWS_PROFILE           |  None   | The AWS environment (dp-bleed-dev, dp-staging, dp-sandbox, dp-production) |
 
 Licence
 -------

--- a/dpypelines/pipeline/dataset_ingress_v1.py
+++ b/dpypelines/pipeline/dataset_ingress_v1.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 from dpytools.logging.logger import DpLogger

--- a/dpypelines/pipeline/dataset_ingress_v1.py
+++ b/dpypelines/pipeline/dataset_ingress_v1.py
@@ -9,7 +9,8 @@ from dpypelines.pipeline.shared.notification import (
 )
 from dpypelines.pipeline.shared.pipelineconfig import matching
 
-logger = DpLogger('data-ingress-pipeline')
+logger = DpLogger("data-ingress-pipeline")
+
 
 def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
     """
@@ -40,19 +41,39 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
     try:
         local_store = LocalDirectoryStore(files_dir)
         files_in_directory = local_store.get_file_names()
-        logger.info("Local data store successfully instansiated", data ={"local_store_dir": files_dir, "files_in_directory": files_in_directory})
+        logger.info(
+            "Local data store successfully instansiated",
+            data={
+                "local_store_dir": files_dir,
+                "files_in_directory": files_in_directory,
+            },
+        )
     except Exception as err:
-        logger.error(f"Failed to access local data at {files_dir}", err, data={"local_store_dir": files_dir})
+        logger.error(
+            f"Failed to access local data at {files_dir}",
+            err,
+            data={"local_store_dir": files_dir},
+        )
         de_notifier.failure()
         raise err
 
     # Extract the patterns for required files from the pipeline configuration
     try:
         required_file_patterns = matching.get_required_files_patterns(pipeline_config)
-        logger.info("Required file patterns retrieved from pipeline configuration", data={"required_file_patterns": required_file_patterns})
+        logger.info(
+            "Required file patterns retrieved from pipeline configuration",
+            data={"required_file_patterns": required_file_patterns},
+        )
     except Exception as err:
         files_in_directory = local_store.get_file_names()
-        logger.error("Failed to get required files pattern", err, data={"pipeline_config": pipeline_config, "files_in_directory": files_in_directory})
+        logger.error(
+            "Failed to get required files pattern",
+            err,
+            data={
+                "pipeline_config": pipeline_config,
+                "files_in_directory": files_in_directory,
+            },
+        )
         de_notifier.failure()
         raise err
 
@@ -60,14 +81,20 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
     for required_file in required_file_patterns:
         try:
             if not local_store.has_lone_file_matching(required_file):
-                raise FileNotFoundError(f"Could not find file matching pattern {required_file}")
+                raise FileNotFoundError(
+                    f"Could not find file matching pattern {required_file}"
+                )
         except Exception as err:
             files_in_directory = local_store.get_file_names()
-            logger.error(f"Error while looking for required file {required_file}", 
-            err, 
-            data={"required_file": required_file, 
-            "required_file_patterns": required_file_patterns, 
-            "files_in_directory": files_in_directory})
+            logger.error(
+                f"Error while looking for required file {required_file}",
+                err,
+                data={
+                    "required_file": required_file,
+                    "required_file_patterns": required_file_patterns,
+                    "files_in_directory": files_in_directory,
+                },
+            )
             de_notifier.failure()
             raise err
 
@@ -76,11 +103,19 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
         supplementary_distribution_patterns = (
             matching.get_supplementary_distribution_patterns(pipeline_config)
         )
-        logger.info("Successfully retrieved supplementary distribution patterns from pipeline config",
-         data={"supplementary_distribution_pattenrs": supplementary_distribution_patterns})
+        logger.info(
+            "Successfully retrieved supplementary distribution patterns from pipeline config",
+            data={
+                "supplementary_distribution_pattenrs": supplementary_distribution_patterns
+            },
+        )
     except Exception as err:
         files_in_directory = local_store.get_file_names()
-        logger.error("Failed to get supplementary distribution patterns", err, data={"pipeline_config": pipeline_config})
+        logger.error(
+            "Failed to get supplementary distribution patterns",
+            err,
+            data={"pipeline_config": pipeline_config},
+        )
         de_notifier.failure()
         raise err
 
@@ -88,14 +123,19 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
     for supplementary_distribution in supplementary_distribution_patterns:
         try:
             if not local_store.has_lone_file_matching(supplementary_distribution):
-                raise FileNotFoundError(f"Could not find file matching pattern {supplementary_distribution}")
+                raise FileNotFoundError(
+                    f"Could not find file matching pattern {supplementary_distribution}"
+                )
         except Exception as err:
-            logger.error(f"Error while looking for supplementary distribution {supplementary_distribution}", 
-            err, 
-            data={"supplementary_distribution": supplementary_distribution,
-            "supplementary_distribution_patterns": supplementary_distribution_patterns,
-            "files_in_directory": files_in_directory,
-            "pipeline_config": pipeline_config}
+            logger.error(
+                f"Error while looking for supplementary distribution {supplementary_distribution}",
+                err,
+                data={
+                    "supplementary_distribution": supplementary_distribution,
+                    "supplementary_distribution_patterns": supplementary_distribution_patterns,
+                    "files_in_directory": files_in_directory,
+                    "pipeline_config": pipeline_config,
+                },
             )
             de_notifier.failure()
             raise err
@@ -106,32 +146,46 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
     for match, sanity_checker in pipeline_config["transform_inputs"].items():
         try:
             input_file_path: Path = local_store.save_lone_file_matching(match)
-            logger.info("Successfully saved file that matches pattern",
-             data={"input_file_path": input_file_path, 
-             "match": match, 
-             "files_in_directory": files_in_directory
-             })
+            logger.info(
+                "Successfully saved file that matches pattern",
+                data={
+                    "input_file_path": input_file_path,
+                    "match": match,
+                    "files_in_directory": files_in_directory,
+                },
+            )
         except Exception as err:
             files_in_directory = local_store.get_file_names()
-            logger.error("Error occured while attempting to save matching pattern file.", 
-            err, 
-            data={"match": match, 
-            "pipeline_config": pipeline_config, 
-            "files_in_directory": files_in_directory})    
+            logger.error(
+                "Error occured while attempting to save matching pattern file.",
+                err,
+                data={
+                    "match": match,
+                    "pipeline_config": pipeline_config,
+                    "files_in_directory": files_in_directory,
+                },
+            )
 
             de_notifier.failure()
             raise err
 
         try:
             sanity_checker(input_file_path)
-            logger.info("Successfully ran sanity check on input file path.", data={"input_file_path": input_file_path})
+            logger.info(
+                "Successfully ran sanity check on input file path.",
+                data={"input_file_path": input_file_path},
+            )
         except Exception as err:
             files_in_directory = local_store.get_file_names()
-            logger.error("Error occured while running sanity checker on input file path.", 
-            err, 
-            data={"input_file_path": input_file_path, 
-            "pipeline_config": pipeline_config, 
-            "files_in_directory": files_in_directory})
+            logger.error(
+                "Error occured while running sanity checker on input file path.",
+                err,
+                data={
+                    "input_file_path": input_file_path,
+                    "pipeline_config": pipeline_config,
+                    "files_in_directory": files_in_directory,
+                },
+            )
 
             de_notifier.failure()
             raise err
@@ -141,27 +195,37 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
     # Get the transform function and keyword arguments from the transform_details
     transform_function = pipeline_config["transform"]
     kwargs = pipeline_config["transform_kwargs"]
-    logger.info("Retrieved transform function and keyword arguments from transform details.",
-     data={"pipeline_config": pipeline_config,
-    "args_got": args,
-    "kwargs_got": kwargs
-    })
+    logger.info(
+        "Retrieved transform function and keyword arguments from transform details.",
+        data={
+            "pipeline_config": pipeline_config,
+            "args_got": args,
+            "kwargs_got": kwargs,
+        },
+    )
 
     try:
         csv_path, metadata_path = transform_function(*args, **kwargs)
-        logger.info("Successfully ran transform function", 
-        data={"pipeline_config": pipeline_config,
-        "csv_path": csv_path,
-        "metadata_path": metadata_path})
+        logger.info(
+            "Successfully ran transform function",
+            data={
+                "pipeline_config": pipeline_config,
+                "csv_path": csv_path,
+                "metadata_path": metadata_path,
+            },
+        )
 
     except Exception as err:
-        logger.error("Error occured while running transform function", 
-        err, 
-        data={"transform_function": transform_function, 
-        "pipeline_config": pipeline_config,
-        "args": args,
-        "kwrags": kwargs
-        })
+        logger.error(
+            "Error occured while running transform function",
+            err,
+            data={
+                "transform_function": transform_function,
+                "pipeline_config": pipeline_config,
+                "args": args,
+                "kwrags": kwargs,
+            },
+        )
         de_notifier.failure()
         raise err
 

--- a/dpypelines/pipeline/dataset_ingress_v1.py
+++ b/dpypelines/pipeline/dataset_ingress_v1.py
@@ -170,33 +170,4 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
 
     # TODO - validate the csv once we know what we're validating
 
-    # ---------------------------------
-    # TODO - delete me at a later point
-    # just an everything is ok alarm for
-    # now so we know the right things happen
-    # ---------------------------------
-
-    with open(metadata_path) as f:
-        metadata = json.load(f)
-
-    import pandas as pd
-
-    de_notifier.success()
-    de_notifier.msg_str(
-        f"""
-
-Tranform ran to completion.
-
-Data Snippet:
-```
-{pd.read_csv(csv_path)[:5]}
-```
-
-Metadata:
-```
-{json.dumps(metadata, indent=2)}
-```
-        """
-    )
-
     print("Worked. I ran to completion.")

--- a/dpypelines/pipeline/shared/transforms/sdmx/compact/v20/prototype/v1.py
+++ b/dpypelines/pipeline/shared/transforms/sdmx/compact/v20/prototype/v1.py
@@ -100,35 +100,44 @@ def xmlToCsvSDMX2_0(input_path, output_path):
     return full_table
 
 
-def generate_versions_metadata(transformedCSV, outputPath, metadataTemplate = False, structureXML = False, config = False):
+def generate_versions_metadata(
+    transformedCSV, outputPath, metadataTemplate=False, structureXML=False, config=False
+):
 
-    # Read in Structure XML provided with the SDMX and tidyCSV we created earlier in the transform 
+    # Read in Structure XML provided with the SDMX and tidyCSV we created earlier in the transform
     if structureXML:
-        with open(structureXML, 'r') as file:
+        with open(structureXML, "r") as file:
             xml_content = file.read()
             data = xmltodict.parse(xml_content)
 
     tidyCSV = pd.read_csv(transformedCSV)
 
     # Pull out the dataset title which we'll use later
-    dataset_title = tidyCSV['TITLE'].iloc[0]
-    
+    dataset_title = tidyCSV["TITLE"].iloc[0]
 
     # Get a list of the concepts and key families from the structure XML which contain info on the data dimensions, at the moment we're basically just using this for the datatype and dimension name where possible
     # this then gets thrown into a dictionary with an entry for each possible dimension header
     if structureXML:
         dimensions = {}
 
-        metadata = data["mes:Structure"]['mes:Concepts']['str:ConceptScheme']['str:Concept']
+        metadata = data["mes:Structure"]["mes:Concepts"]["str:ConceptScheme"][
+            "str:Concept"
+        ]
 
         for concept in metadata:
-            set_key(dimensions, concept['@id'],  concept['@id'].lower())
-            set_key(dimensions, concept['@id'],  concept['str:Name']['#text'])
-        
-        metadata = data["mes:Structure"]['mes:KeyFamilies']['str:KeyFamily']['str:Components']['str:Dimension']
+            set_key(dimensions, concept["@id"], concept["@id"].lower())
+            set_key(dimensions, concept["@id"], concept["str:Name"]["#text"])
+
+        metadata = data["mes:Structure"]["mes:KeyFamilies"]["str:KeyFamily"][
+            "str:Components"
+        ]["str:Dimension"]
 
         for concept in metadata:
-            set_key(dimensions, concept['@conceptRef'], concept['str:TextFormat']['@textType'])
+            set_key(
+                dimensions,
+                concept["@conceptRef"],
+                concept["str:TextFormat"]["@textType"],
+            )
 
     # Here we're going through each header in the tidyCSV and attempting to match it up with the DSD informaion we got before, for other headers (such as the metadata columns) we assume the datatype is just a string
     full_dimensions = {}
@@ -139,23 +148,23 @@ def generate_versions_metadata(transformedCSV, outputPath, metadataTemplate = Fa
                 full_dimensions[column] = column
                 if len(dimensions[column]) == 3:
                     set_key(full_dimensions, column, dimensions[column][0])
-                    set_key(full_dimensions, column, dimensions[column][1])   
-                    set_key(full_dimensions, column, dimensions[column][2])          
+                    set_key(full_dimensions, column, dimensions[column][1])
+                    set_key(full_dimensions, column, dimensions[column][2])
                 else:
                     set_key(full_dimensions, column, dimensions[column][0])
                     set_key(full_dimensions, column, dimensions[column][1])
-                    set_key(full_dimensions, column, 'string')
+                    set_key(full_dimensions, column, "string")
             else:
                 full_dimensions[column] = column
                 set_key(full_dimensions, column, column.lower())
                 set_key(full_dimensions, column, column.lower())
-                set_key(full_dimensions, column, 'string')
+                set_key(full_dimensions, column, "string")
     else:
         for column in tidyCSV.columns:
             full_dimensions[column] = column
             set_key(full_dimensions, column, column.lower())
             set_key(full_dimensions, column, column.lower())
-            set_key(full_dimensions, column, 'string')
+            set_key(full_dimensions, column, "string")
 
     full_dimensions_list = list(full_dimensions.values())
 
@@ -168,75 +177,109 @@ def generate_versions_metadata(transformedCSV, outputPath, metadataTemplate = Fa
         versions_template = {}
 
     # now a very terrible and hardcoded implementation of applying what little metadata we have to as many fields as possible
-    
-    versions_template['title'] = dataset_title
-    versions_template['description'] = ""
-    versions_template['summary'] = ""
-    versions_template['identifier'] = 'https://staging.idpd.uk/datasets/' + pathify(dataset_title) + '/editions'
+
+    versions_template["title"] = dataset_title
+    versions_template["description"] = ""
+    versions_template["summary"] = ""
+    versions_template["identifier"] = (
+        "https://staging.idpd.uk/datasets/" + pathify(dataset_title) + "/editions"
+    )
     if structureXML:
-        versions_template['issued'] = data["mes:Structure"]['mes:Header']['mes:Prepared'].split('.')[0] + 'Z'
+        versions_template["issued"] = (
+            data["mes:Structure"]["mes:Header"]["mes:Prepared"].split(".")[0] + "Z"
+        )
     else:
-        versions_template['issued'] = ""
-    versions_template['license'] = "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-    versions_template['modified'] = tidyCSV['Extracted'].iloc[0].split('+')[0] + 'Z' # This is working off the assumption that every extraction date is a new modification of the data
-    versions_template['next_release'] = "" # could we infer this from issued date and release frequency if we include that in the config?
-    versions_template['publisher']  = {'email': "", 
-                                       'name' : "",
-                                       'telephone' : ""} # config file?
-    versions_template['frequency'] = "" # config file?
-    versions_template['spatial_coverage'] = list(tidyCSV.REF_AREA.unique())[0] # this will need investigation into whether this is accurate to what we need for this field
-    versions_template['spatial_resolution'] = list(tidyCSV.COUNTERPART_AREA.unique()) # this will need investigation into whether this is accurate to what we need for this field
-    versions_template['temporal_coverage'] = 'start: ' + str(min(tidyCSV.TIME_PERIOD)) + ', end: ' + str(max(tidyCSV.TIME_PERIOD)) # I'll need to input on the formatting of this field cause the previous iteration was a dictionry but the spec has it now as a string
-    versions_template['temporal_resolution'] = list(tidyCSV.TIME_FORMAT.unique())[0] # this will need investigation into whether this is accurate to what we need for this field
-    versions_template['contact_point']  = { 'email': "", 
-                                            'name' : "",
-                                            'telephone' : ""} # config file?
-    versions_template['keywords'] = ["", ""] 
-    versions_template['themes'] = ["", ""] 
+        versions_template["issued"] = ""
+    versions_template["license"] = (
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+    )
+    versions_template["modified"] = (
+        tidyCSV["Extracted"].iloc[0].split("+")[0] + "Z"
+    )  # This is working off the assumption that every extraction date is a new modification of the data
+    versions_template["next_release"] = (
+        ""  # could we infer this from issued date and release frequency if we include that in the config?
+    )
+    versions_template["publisher"] = {
+        "email": "",
+        "name": "",
+        "telephone": "",
+    }  # config file?
+    versions_template["frequency"] = ""  # config file?
+    versions_template["spatial_coverage"] = list(tidyCSV.REF_AREA.unique())[
+        0
+    ]  # this will need investigation into whether this is accurate to what we need for this field
+    versions_template["spatial_resolution"] = list(
+        tidyCSV.COUNTERPART_AREA.unique()
+    )  # this will need investigation into whether this is accurate to what we need for this field
+    versions_template["temporal_coverage"] = (
+        "start: "
+        + str(min(tidyCSV.TIME_PERIOD))
+        + ", end: "
+        + str(max(tidyCSV.TIME_PERIOD))
+    )  # I'll need to input on the formatting of this field cause the previous iteration was a dictionry but the spec has it now as a string
+    versions_template["temporal_resolution"] = list(tidyCSV.TIME_FORMAT.unique())[
+        0
+    ]  # this will need investigation into whether this is accurate to what we need for this field
+    versions_template["contact_point"] = {
+        "email": "",
+        "name": "",
+        "telephone": "",
+    }  # config file?
+    versions_template["keywords"] = ["", ""]
+    versions_template["themes"] = ["", ""]
 
     columns = []
     for i in full_dimensions_list:
         column = {}
-        column['component_type'] = "" 
-        column['datatype'] = i[3]
-        column['name'] = i[0]        
-        column['titles'] = i[1]
-        column['property_url'] =  "" 
-        column['value_url'] =  "" 
-        column['codelist_url'] =  "" 
-        column['sub_property_of'] =  "" 
+        column["component_type"] = ""
+        column["datatype"] = i[3]
+        column["name"] = i[0]
+        column["titles"] = i[1]
+        column["property_url"] = ""
+        column["value_url"] = ""
+        column["codelist_url"] = ""
+        column["sub_property_of"] = ""
         columns.append(column)
 
     table_schema = {}
-    table_schema['about_url'] = ""
-    table_schema['column'] = columns
+    table_schema["about_url"] = ""
+    table_schema["column"] = columns
 
     distributions = []
 
-    distribution = { "checksum": "",
-                     "@id": "",
-                     "byte_size": "",
-                     "media_type": "",
-                     "download_url": "",
-                     "described_by": "", 
-                     "table_schema": table_schema}
-    
-    distributions.append(distribution) # at some point we'll need to pull in any previous existing distributions but im assuming a lot of this script will change when we get that far
-    
-    versions_template['distributions'] = distributions
-    versions_template['version_notes'] = [""]
-    versions_template['@context'] = ""
-    versions_template['@id'] = "" # Is this the same as the initial identifier?
-    versions_template['@type'] = "dcat:dataset"
-    versions_template['etag'] = "" # ?
-    versions_template['is_based_on'] = {"id" : "", "type" : ""} # ?
-    versions_template["_embedded"] = {"code_list": "string", "identifier": "string", "label": "string", "name": "string"}
-    versions_template['type'] = "" # ?
-    versions_template['state'] = "" # ?
+    distribution = {
+        "checksum": "",
+        "@id": "",
+        "byte_size": "",
+        "media_type": "",
+        "download_url": "",
+        "described_by": "",
+        "table_schema": table_schema,
+    }
+
+    distributions.append(
+        distribution
+    )  # at some point we'll need to pull in any previous existing distributions but im assuming a lot of this script will change when we get that far
+
+    versions_template["distributions"] = distributions
+    versions_template["version_notes"] = [""]
+    versions_template["@context"] = ""
+    versions_template["@id"] = ""  # Is this the same as the initial identifier?
+    versions_template["@type"] = "dcat:dataset"
+    versions_template["etag"] = ""  # ?
+    versions_template["is_based_on"] = {"id": "", "type": ""}  # ?
+    versions_template["_embedded"] = {
+        "code_list": "string",
+        "identifier": "string",
+        "label": "string",
+        "name": "string",
+    }
+    versions_template["type"] = ""  # ?
+    versions_template["state"] = ""  # ?
 
     # dump out metadata file
 
-    #with open(str(outputPath) + pathify(dataset_title) + "_" + str(datetime.now().strftime("%Y-%m")) + "-metadata.json", "w") as outfile:
+    # with open(str(outputPath) + pathify(dataset_title) + "_" + str(datetime.now().strftime("%Y-%m")) + "-metadata.json", "w") as outfile:
     #    json.dump(versions_template, outfile, ensure_ascii=False, indent=4)
     with open(outputPath, "w") as outfile:
         json.dump(versions_template, outfile, ensure_ascii=False, indent=4)

--- a/dpypelines/pipeline/shared/transforms/utils.py
+++ b/dpypelines/pipeline/shared/transforms/utils.py
@@ -11,6 +11,7 @@ def pathify(label):
         r"-$", "", re.sub(r"-+", "-", re.sub(r"[^\w/]", "-", unidecode(label).lower()))
     )
 
+
 def set_key(dictionary, key, value):
     if key not in dictionary:
         dictionary[key] = value

--- a/tests/pipelines/pipeline/shared/test_message.py
+++ b/tests/pipelines/pipeline/shared/test_message.py
@@ -50,6 +50,7 @@ def test_cant_find_scheama():
     assert "Error: Something went wrong" in human_readable_output
     assert isinstance(human_readable_output, str)
 
+
 def test_invalid_config():
     error = Exception("Something went wrong")
     config_dict = {


### PR DESCRIPTION
### What

Remove the "everything is ok" alarm where we punt details of the transform and metadata into slack.

Was only a sanity check until we had acceptance tests which we now do (and its spectacularly verbose now that we have metadata output).

I also removed an env var reference from the readme, not something thats used by this repo
 

### How to review

Sanity check

### Who can review

Anyone