### PR TITLE
Functions added to get transform details from config

### DIFF
--- a/dpypelines/pipeline/dataset_ingress_v1.py
+++ b/dpypelines/pipeline/dataset_ingress_v1.py
@@ -6,7 +6,6 @@ from dpytools.http.upload import UploadServiceClient
 from dpytools.logging.logger import DpLogger
 from dpytools.stores.directory.local import LocalDirectoryStore
 
-from dpypelines.pipeline.shared import message
 from dpypelines.pipeline.shared.email_template_message import (
     file_not_found_email,
     submission_processed_email,
@@ -16,62 +15,62 @@ from dpypelines.pipeline.shared.notification import (
     BasePipelineNotifier,
     notifier_from_env_var_webhook,
 )
-from dpypelines.pipeline.shared.pipelineconfig import matching
+from dpypelines.pipeline.shared.pipelineconfig.matching import (
+    get_required_files_patterns,
+    get_supplementary_distribution_patterns,
+)
+from dpypelines.pipeline.shared.pipelineconfig.transform import (
+    get_transform_function,
+    get_transform_inputs,
+    get_transform_kwargs,
+)
 from dpypelines.pipeline.shared.utils import (
     get_email_client,
     get_florence_access_token,
     get_submitter_email,
 )
 
-logger = DpLogger("data-ingress-pipeline")
+logger = DpLogger("data-ingress-pipeline-v1")
 
 
 def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
     """
-    Version one of the dataset ingress pipeline.
-
-    files_dir: Path to the directory where the input
-    files for this pipeline are located.
+    Version 1 of the dataset ingress pipeline.
 
     Args:
         files_dir (str): Path to the directory where the input files for this pipeline are located.
         pipeline_config (dict): Dictionary of configuration details required to run the pipeline (determined by dataset id)
 
     Raises:
-        ValueError: If required files, supplementary distributions, or pipeline configuration are not found in the input directory.
-        Exception: If any other unexpected error occurs.
+        Exception: If any unexpected error occurs.
     """
     # Create notifier from webhook env var
     try:
         de_notifier: BasePipelineNotifier = notifier_from_env_var_webhook(
             "DE_SLACK_WEBHOOK"
         )
-        logger.info("Created notifier instance", data={"notifier": de_notifier})
+        logger.info("Notifier created", data={"notifier": de_notifier})
     except Exception as err:
-        logger.error("Error occurred while attempting to create notifier instance", err)
+        logger.error("Error occurred when creating notifier", err)
         raise err
 
     try:
         submitter_email = get_submitter_email()
         logger.info(
-            "Successfully got submitter email",
+            "Got submitter email",
             data={"submitter_email": submitter_email},
         )
     except Exception as err:
-        logger.error("Error occurred while attempting to get submitter email", err)
+        logger.error("Error occurred when getting submitter email", err)
         de_notifier.failure()
         raise err
 
     # Create email client from env var
     try:
         email_client = get_email_client()
-        logger.info(
-            "Created email client instance", data={"email_client": email_client}
-        )
+        logger.info("Created email client", data={"email_client": email_client})
     except Exception as err:
-        logger.error(
-            "Error occurred while attempting to create email client instance", err
-        )
+        logger.error("Error occurred when creating email client", err)
         de_notifier.failure()
         raise err
 
@@ -80,13 +79,13 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
         email_content = submission_processed_email()
         email_client.send(submitter_email, email_content.subject, email_content.message)
         logger.info(
-            "Successfully sent email",
+            "Email sent",
             data={"submitter_email": submitter_email, "email_content": email_content},
         )
     except Exception as err:
-        logger.error("Error occurred while attempting to send email", err)
+        logger.error("Error occurred when sending email", err)
         de_notifier.failure()
-        raise Exception(message.unexpected_error("Failed to send email", err)) from err
+        raise err
 
     # Get Upload Service URL from environment variable
     try:
@@ -96,7 +95,7 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
         ), "UPLOAD_SERVICE_URL environment variable not set."
         logger.info("Got Upload Service URL", data={"upload_url": upload_url})
     except Exception as err:
-        logger.error("Error getting Upload Service URL", err)
+        logger.error("Error occurred when getting Upload Service URL", err)
         de_notifier.failure()
         raise err
 
@@ -108,7 +107,7 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
         ), "FLORENCE_TOKEN environment variable not set."
         logger.info("Got Florence access token")
     except Exception as err:
-        logger.error("Error getting Florence access token", err)
+        logger.error("Error occurred when getting Florence access token", err)
         de_notifier.failure()
         raise err
 
@@ -117,7 +116,7 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
         local_store = LocalDirectoryStore(files_dir)
         files_in_directory = local_store.get_file_names()
         logger.info(
-            "Local data store successfully instantiated",
+            "Local data store created",
             data={
                 "local_store_dir": files_dir,
                 "files_in_directory": files_in_directory,
@@ -125,7 +124,7 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
         )
     except Exception as err:
         logger.error(
-            f"Failed to access local data at {files_dir}",
+            "Error occurred when creating local data store from files directory",
             err,
             data={"local_store_dir": files_dir},
         )
@@ -134,19 +133,19 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
 
     # Extract the patterns for required files from the pipeline configuration
     try:
-        required_file_patterns = matching.get_required_files_patterns(pipeline_config)
+        required_file_patterns = get_required_files_patterns(pipeline_config)
         logger.info(
-            "Required file patterns retrieved from pipeline configuration",
+            "Required file patterns retrieved from pipeline config",
             data={"required_file_patterns": required_file_patterns},
         )
     except Exception as err:
         files_in_directory = local_store.get_file_names()
         logger.error(
-            "Failed to get required files pattern",
+            "Error occurred when getting required file patterns",
             err,
             data={
-                "pipeline_config": pipeline_config,
                 "files_in_directory": files_in_directory,
+                "pipeline_config": pipeline_config,
             },
         )
         de_notifier.failure()
@@ -161,21 +160,23 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
                     submitter_email, email_content.subject, email_content.message
                 )
                 logger.info(
-                    "Sent email to submitter: ",
-                    submitter_email,
-                    " about missing required file: ",
-                    required_file,
+                    "Email sent to submitter about missing required file",
+                    data={
+                        "submitter_email": submitter_email,
+                        "required_file": required_file,
+                    },
                 )
                 de_notifier.failure()
         except Exception as err:
             files_in_directory = local_store.get_file_names()
             logger.error(
-                f"Error while looking for required file {required_file}",
+                "Error occurred when looking for required file",
                 err,
                 data={
                     "required_file": required_file,
                     "required_file_patterns": required_file_patterns,
                     "files_in_directory": files_in_directory,
+                    "pipeline_config": pipeline_config,
                 },
             )
             de_notifier.failure()
@@ -183,17 +184,15 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
 
     # Extract the patterns for supplementary distributions from the pipeline configuration
     try:
-        supp_dist_patterns = matching.get_supplementary_distribution_patterns(
-            pipeline_config
-        )
+        supp_dist_patterns = get_supplementary_distribution_patterns(pipeline_config)
         logger.info(
-            "Successfully retrieved supplementary distribution patterns from pipeline config",
+            "Supplementary distribution patterns retrieved from pipeline config",
             data={"supplementary_distribution_patterns": supp_dist_patterns},
         )
     except Exception as err:
         files_in_directory = local_store.get_file_names()
         logger.error(
-            "Failed to get supplementary distribution patterns",
+            "Error occurred when getting supplementary distribution patterns",
             err,
             data={"pipeline_config": pipeline_config},
         )
@@ -211,15 +210,16 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
                     submitter_email, email_content.subject, email_content.message
                 )
                 logger.info(
-                    "Sent email to submitter: ",
-                    submitter_email,
-                    " about missing supplementary distribution: ",
-                    supp_dist_pattern,
+                    "Email sent to submitter about missing supplementary distribution file",
+                    data={
+                        "submitter_email": submitter_email,
+                        "supplementary_distribution_pattern": supp_dist_pattern,
+                    },
                 )
                 de_notifier.failure()
         except Exception as err:
             logger.error(
-                f"Error while looking for supplementary distribution {supp_dist_pattern}",
+                "Error occurred when looking for supplementary distribution",
                 err,
                 data={
                     "supplementary_distribution": supp_dist_pattern,
@@ -231,29 +231,38 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
             de_notifier.failure()
             raise err
 
-    # Get the positional arguments (the inputs) from the pipeline_config
-    # dict and run the specified sanity checker for it
-    args = []
-    for match, sanity_checker in pipeline_config["transform_inputs"].items():
+    # Get the transform inputs from the pipeline_config and run the specified sanity checker for it
+    input_file_paths = []
+    try:
+        transform_inputs = get_transform_inputs(pipeline_config)
+        logger.info("Got transform inputs", data={"transform_inputs": transform_inputs})
+    except Exception as err:
+        logger.error(
+            "Error when getting transform inputs from pipeline config",
+            err,
+            data={"pipeline_config": pipeline_config},
+        )
+
+    for pattern, sanity_checker in transform_inputs.items():
         try:
-            input_file_path: Path = local_store.save_lone_file_matching(match)
+            input_file_path: Path = local_store.save_lone_file_matching(pattern)
             logger.info(
-                "Successfully saved file that matches pattern",
+                "Saved input file that matches pattern",
                 data={
                     "input_file_path": input_file_path,
-                    "match": match,
+                    "pattern": pattern,
                     "files_in_directory": files_in_directory,
                 },
             )
         except Exception as err:
             files_in_directory = local_store.get_file_names()
             logger.error(
-                "Error occurred while attempting to save matching pattern file.",
+                "Error occurred when looking for file matching pattern",
                 err,
                 data={
-                    "match": match,
-                    "pipeline_config": pipeline_config,
+                    "pattern": pattern,
                     "files_in_directory": files_in_directory,
+                    "pipeline_config": pipeline_config,
                 },
             )
             de_notifier.failure()
@@ -262,57 +271,82 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
         try:
             sanity_checker(input_file_path)
             logger.info(
-                "Successfully ran sanity check on input file path.",
-                data={"input_file_path": input_file_path},
+                "Sanity check run on input file path.",
+                data={
+                    "sanity_checker": sanity_checker,
+                    "input_file_path": input_file_path,
+                },
             )
         except Exception as err:
             files_in_directory = local_store.get_file_names()
             logger.error(
-                "Error occurred while running sanity checker on input file path.",
+                "Error occurred when running sanity checker on input file path.",
                 err,
                 data={
                     "input_file_path": input_file_path,
-                    "pipeline_config": pipeline_config,
                     "files_in_directory": files_in_directory,
+                    "pipeline_config": pipeline_config,
                 },
             )
 
             de_notifier.failure()
             raise err
 
-        args.append(input_file_path)
+        input_file_paths.append(input_file_path)
 
-    # Get the transform function and keyword arguments from the transform_details
-    transform_function = pipeline_config["transform"]
-    kwargs = pipeline_config["transform_kwargs"]
-    logger.info(
-        "Retrieved transform function and keyword arguments from transform details.",
-        data={
-            "pipeline_config": pipeline_config,
-            "args_got": args,
-            "kwargs_got": kwargs,
-        },
-    )
+    # Get the transform function from pipeline config
+    try:
+        transform_function = get_transform_function(pipeline_config)
+        logger.info(
+            "Got transform function from pipeline config",
+            data={
+                "transform_function": transform_function,
+                "input_file_paths": input_file_paths,
+            },
+        )
+    except Exception as err:
+        logger.error(
+            "Error occurred when getting transform function from pipeline config",
+            err,
+            data={"pipeline_config": pipeline_config},
+        )
+    # Get transform keyword arguments (kwargs) from pipeline config
+    try:
+        transform_kwargs = get_transform_kwargs(pipeline_config)
+        logger.info(
+            "Got transform kwargs from pipeline config",
+            data={"transform_kwargs": transform_kwargs},
+        )
+    except Exception as err:
+        logger.error(
+            "Error occurred when getting transform kwargs from pipeline config",
+            err,
+            data={"pipeline_config": pipeline_config},
+        )
 
     try:
-        csv_path, metadata_path = transform_function(*args, **kwargs)
+        csv_path, metadata_path = transform_function(
+            *input_file_paths, **transform_kwargs
+        )
         logger.info(
             "Successfully ran transform function",
             data={
-                "pipeline_config": pipeline_config,
+                "transform_function": transform_function,
+                "input_file_paths": input_file_paths,
+                "transform_kwargs": transform_kwargs,
                 "csv_path": csv_path,
                 "metadata_path": metadata_path,
             },
         )
     except Exception as err:
         logger.error(
-            "Error occurred while running transform function",
+            "Error occurred when running transform function",
             err,
             data={
                 "transform_function": transform_function,
+                "input_file_paths": input_file_paths,
+                "transform_kwargs": transform_kwargs,
                 "pipeline_config": pipeline_config,
-                "args": args,
-                "kwargs": kwargs,
             },
         )
         de_notifier.failure()
@@ -364,7 +398,7 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
     if supp_dist_patterns:
         # Get list of all files in local store
         all_files = local_store.get_file_names()
-        logger.info("Got files", data={"files": all_files})
+        logger.info("Got all files in local store", data={"files": all_files})
         for supp_dist_pattern in supp_dist_patterns:
             # Get supplementary distribution filename matching pattern from local store
             supp_dist_matching_files = [

--- a/dpypelines/pipeline/dataset_ingress_v1.py
+++ b/dpypelines/pipeline/dataset_ingress_v1.py
@@ -203,20 +203,25 @@ def dataset_ingress_v1(files_dir: str, pipeline_config: dict):
     for supp_dist_pattern in supp_dist_patterns:
         try:
             if not local_store.has_lone_file_matching(supp_dist_pattern):
+                err = FileNotFoundError(
+                    f"No file found matching pattern {supp_dist_pattern}"
+                )
                 email_content = supplementary_distribution_not_found_email(
                     supp_dist_pattern
                 )
                 email_client.send(
                     submitter_email, email_content.subject, email_content.message
                 )
-                logger.info(
+                logger.error(
                     "Email sent to submitter about missing supplementary distribution file",
+                    err,
                     data={
                         "submitter_email": submitter_email,
                         "supplementary_distribution_pattern": supp_dist_pattern,
                     },
                 )
                 de_notifier.failure()
+                raise err
         except Exception as err:
             logger.error(
                 "Error occurred when looking for supplementary distribution",

--- a/dpypelines/pipeline/shared/pipelineconfig/transform.py
+++ b/dpypelines/pipeline/shared/pipelineconfig/transform.py
@@ -1,0 +1,44 @@
+import json
+from typing import Callable, Dict
+
+
+def get_transform_inputs(config: dict) -> Dict[str, Callable]:
+    if config["config_version"] == 1:
+        assert (
+            "transform_inputs" in config.keys()
+        ), f"""'transform_inputs' not found in config dictionary:
+        {json.dumps(config, indent=2, default=lambda x: str(x))}"""
+        transform_inputs = config["transform_inputs"]
+        return transform_inputs
+    else:
+        raise NotImplementedError(
+            f"Config version {config['config_version']} not recognised"
+        )
+
+
+def get_transform_function(config: dict) -> Callable:
+    if config["config_version"] == 1:
+        assert (
+            "transform" in config.keys()
+        ), f"""'transform' not found in config dictionary:
+        {json.dumps(config, indent=2, default=lambda x: str(x))}"""
+        transform_function = config["transform"]
+        return transform_function
+    else:
+        raise NotImplementedError(
+            f"Config version {config['config_version']} not recognised"
+        )
+
+
+def get_transform_kwargs(config: dict) -> dict:
+    if config["config_version"] == 1:
+        assert (
+            "transform_kwargs" in config.keys()
+        ), f"""'transform_kwargs' not found in config dictionary:
+        {json.dumps(config, indent=2, default=lambda x: str(x))}"""
+        transform_kwargs = config["transform_kwargs"]
+        return transform_kwargs
+    else:
+        raise NotImplementedError(
+            f"Config version {config['config_version']} not recognised"
+        )

--- a/tests/pipelines/pipeline/shared/pipelineconfig/test_transform.py
+++ b/tests/pipelines/pipeline/shared/pipelineconfig/test_transform.py
@@ -1,0 +1,142 @@
+import pytest
+
+from dpypelines.pipeline.dataset_ingress_v1 import dataset_ingress_v1
+from dpypelines.pipeline.shared.pipelineconfig.transform import (
+    get_transform_function,
+    get_transform_inputs,
+    get_transform_kwargs,
+)
+from dpypelines.pipeline.shared.transforms.sdmx.v1 import (
+    sdmx_compact_2_0_prototype_1,
+    sdmx_sanity_check_v1,
+)
+
+
+def test_get_transform_function():
+    config = {
+        "config_version": 1,
+        "transform": sdmx_compact_2_0_prototype_1,
+        "transform_inputs": {"^data.xml$": sdmx_sanity_check_v1},
+        "transform_kwargs": {},
+        "required_files": [{"matches": "^data.xml$", "count": "1"}],
+        "supplementary_distributions": [{"matches": "^data.xml$", "count": "1"}],
+        "secondary_function": dataset_ingress_v1,
+    }
+    result = get_transform_function(config)
+    assert result.__name__ == "sdmx_compact_2_0_prototype_1"
+
+
+def test_get_transform_function_missing():
+    config = {
+        "config_version": 1,
+        "transform_inputs": {"^data.xml$": sdmx_sanity_check_v1},
+        "transform_kwargs": {},
+        "required_files": [{"matches": "^data.xml$", "count": "1"}],
+        "supplementary_distributions": [{"matches": "^data.xml$", "count": "1"}],
+        "secondary_function": dataset_ingress_v1,
+    }
+    with pytest.raises(AssertionError) as err:
+        get_transform_function(config)
+    assert "'transform' not found in config dictionary" in str(err.value)
+
+
+def test_get_transform_function_invalid_config_version():
+    config = {
+        "config_version": 2,
+        "transform": sdmx_compact_2_0_prototype_1,
+        "transform_inputs": {"^data.xml$": sdmx_sanity_check_v1},
+        "transform_kwargs": {},
+        "required_files": [{"matches": "^data.xml$", "count": "1"}],
+        "supplementary_distributions": [{"matches": "^data.xml$", "count": "1"}],
+        "secondary_function": dataset_ingress_v1,
+    }
+    with pytest.raises(NotImplementedError) as err:
+        get_transform_function(config)
+    assert "Config version 2 not recognised" in str(err.value)
+
+
+def test_get_transform_inputs():
+    config = {
+        "config_version": 1,
+        "transform": sdmx_compact_2_0_prototype_1,
+        "transform_inputs": {"^data.xml$": sdmx_sanity_check_v1},
+        "transform_kwargs": {},
+        "required_files": [{"matches": "^data.xml$", "count": "1"}],
+        "supplementary_distributions": [{"matches": "^data.xml$", "count": "1"}],
+        "secondary_function": dataset_ingress_v1,
+    }
+    result = get_transform_inputs(config)
+    assert "^data.xml$" in result.keys()
+    assert result["^data.xml$"].__name__ == "sdmx_sanity_check_v1"
+
+
+def test_get_transform_inputs_missing():
+    config = {
+        "config_version": 1,
+        "transform": sdmx_compact_2_0_prototype_1,
+        "transform_kwargs": {},
+        "required_files": [{"matches": "^data.xml$", "count": "1"}],
+        "supplementary_distributions": [{"matches": "^data.xml$", "count": "1"}],
+        "secondary_function": dataset_ingress_v1,
+    }
+    with pytest.raises(AssertionError) as err:
+        get_transform_inputs(config)
+    assert "'transform_inputs' not found in config dictionary" in str(err.value)
+
+
+def test_get_transform_inputs_invalid_config_version():
+    config = {
+        "config_version": 2,
+        "transform": sdmx_compact_2_0_prototype_1,
+        "transform_inputs": {"^data.xml$": sdmx_sanity_check_v1},
+        "transform_kwargs": {},
+        "required_files": [{"matches": "^data.xml$", "count": "1"}],
+        "supplementary_distributions": [{"matches": "^data.xml$", "count": "1"}],
+        "secondary_function": dataset_ingress_v1,
+    }
+    with pytest.raises(NotImplementedError) as err:
+        get_transform_inputs(config)
+    assert "Config version 2 not recognised" in str(err.value)
+
+
+def test_get_transform_kwargs():
+    config = {
+        "config_version": 1,
+        "transform": sdmx_compact_2_0_prototype_1,
+        "transform_inputs": {"^data.xml$": sdmx_sanity_check_v1},
+        "transform_kwargs": {"kwarg1": "value1"},
+        "required_files": [{"matches": "^data.xml$", "count": "1"}],
+        "supplementary_distributions": [{"matches": "^data.xml$", "count": "1"}],
+        "secondary_function": dataset_ingress_v1,
+    }
+    result = get_transform_kwargs(config)
+    assert result == {"kwarg1": "value1"}
+
+
+def test_get_transform_kwargs_missing():
+    config = {
+        "config_version": 1,
+        "transform": sdmx_compact_2_0_prototype_1,
+        "transform_inputs": {"^data.xml$": sdmx_sanity_check_v1},
+        "required_files": [{"matches": "^data.xml$", "count": "1"}],
+        "supplementary_distributions": [{"matches": "^data.xml$", "count": "1"}],
+        "secondary_function": dataset_ingress_v1,
+    }
+    with pytest.raises(AssertionError) as err:
+        get_transform_kwargs(config)
+    assert "'transform_kwargs' not found in config dictionary" in str(err.value)
+
+
+def test_get_transform_kwargs_invalid_config_version():
+    config = {
+        "config_version": 2,
+        "transform": sdmx_compact_2_0_prototype_1,
+        "transform_inputs": {"^data.xml$": sdmx_sanity_check_v1},
+        "transform_kwargs": {},
+        "required_files": [{"matches": "^data.xml$", "count": "1"}],
+        "supplementary_distributions": [{"matches": "^data.xml$", "count": "1"}],
+        "secondary_function": dataset_ingress_v1,
+    }
+    with pytest.raises(NotImplementedError) as err:
+        get_transform_kwargs(config)
+    assert "Config version 2 not recognised" in str(err.value)


### PR DESCRIPTION
### What

Three functions added (in `dpypelines/pipeline/shared/pipelineconfig/transform.py`) to get transform inputs, transform function and transform kwargs from pipeline config dict. `dataset_ingress_v1()` updated to use new functions instead of hardcoded values. Associated tests added in `tests/pipelines/pipeline/shared/pipelineconfig/test_transform.py`. Tided up some logging statements in `dataset_ingress_v1()`.

### How to review

Sanity check, make sure `dataset_ingress_v1()` runs up to L321.

### Who can review

Anyone.