### PR TITLE
Bug fix `get_commit_id()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ __pycache__
 .coverage
 behave_debug.py
 features/fixtures/data/
-data/*
+data

--- a/dpypelines/pipeline/shared/notification.py
+++ b/dpypelines/pipeline/shared/notification.py
@@ -1,10 +1,10 @@
 import os
 from abc import ABC, abstractmethod
 
-from dpypelines.pipeline.shared.utils import get_commit_id
 from dpytools.slack.slack import SlackMessenger
+from dpytools.utilities.utilities import str_to_bool
 
-from dpypelines.pipeline.shared.utils import str_to_bool
+from dpypelines.pipeline.shared.utils import get_commit_id
 
 
 class BasePipelineNotifier(ABC):

--- a/dpypelines/pipeline/shared/notification.py
+++ b/dpypelines/pipeline/shared/notification.py
@@ -1,7 +1,7 @@
 import os
 from abc import ABC, abstractmethod
 
-from dpytools.logging.utility import get_commit_ID
+from dpypelines.pipeline.shared.utils import get_commit_id
 from dpytools.slack.slack import SlackMessenger
 
 from dpypelines.pipeline.shared.utils import str_to_bool
@@ -53,11 +53,11 @@ class PipelineNotifier(BasePipelineNotifier):
         self.notification_postfix = os.environ.get("NOTIFICATION_POSTFIX", "")
 
     def failure(self):
-        msg = f":x: {self.notification_postfix}, commit ID: {get_commit_ID()}".strip()
+        msg = f":x: {self.notification_postfix}, commit ID: {get_commit_id()}".strip()
         self.client.msg_str(msg)
 
     def success(self):
-        msg = f":white_check_mark: {self.notification_postfix}, commit ID: {get_commit_ID()}".strip()
+        msg = f":white_check_mark: {self.notification_postfix}, commit ID: {get_commit_id()}".strip()
         self.client.msg_str(msg)
 
     # TODO - remove me later

--- a/dpypelines/pipeline/shared/utils.py
+++ b/dpypelines/pipeline/shared/utils.py
@@ -6,6 +6,7 @@ import os
 from dpytools.email.ses.client import SesClient
 from dpytools.utilities.utilities import str_to_bool
 from email_validator import EmailNotValidError, validate_email
+import git
 
 
 class NopEmailClient:
@@ -49,3 +50,11 @@ def get_submitter_email(manifest_dict: dict) -> str:
         raise ValueError(f"Invalid email address: {submitter_email}. Error: {str(e)}")
 
     return submitter_email
+
+
+def get_commit_id():
+    repo = git.Repo()
+    heads = repo.heads
+    sandbox = heads[0]
+    cmt = sandbox.commit
+    return cmt

--- a/dpypelines/pipeline/shared/utils.py
+++ b/dpypelines/pipeline/shared/utils.py
@@ -6,7 +6,7 @@ import os
 from dpytools.email.ses.client import SesClient
 from dpytools.utilities.utilities import str_to_bool
 from email_validator import EmailNotValidError, validate_email
-import git
+from git import Repo
 
 
 class NopEmailClient:
@@ -52,9 +52,6 @@ def get_submitter_email(manifest_dict: dict) -> str:
     return submitter_email
 
 
-def get_commit_id():
-    repo = git.Repo()
-    heads = repo.heads
-    sandbox = heads[0]
-    cmt = sandbox.commit
-    return cmt
+def get_commit_id() -> str:
+    repo = Repo()
+    return str(repo.head.commit)

--- a/poetry.lock
+++ b/poetry.lock
@@ -448,6 +448,38 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "gitdb"
+version = "4.0.11"
+description = "Git Object Database"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "gitdb-4.0.11-py3-none-any.whl", hash = "sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4"},
+    {file = "gitdb-4.0.11.tar.gz", hash = "sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b"},
+]
+
+[package.dependencies]
+smmap = ">=3.0.1,<6"
+
+[[package]]
+name = "gitpython"
+version = "3.1.43"
+description = "GitPython is a Python library used to interact with Git repositories"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "GitPython-3.1.43-py3-none-any.whl", hash = "sha256:eec7ec56b92aad751f9912a73404bc02ba212a23adb2c7098ee668417051a1ff"},
+    {file = "GitPython-3.1.43.tar.gz", hash = "sha256:35f314a9f878467f5453cc1fee295c3e18e52f1b99f10f6cf5b1682e968a9e7c"},
+]
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
+
+[package.extras]
+doc = ["sphinx (==4.3.2)", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "sphinxcontrib-applehelp (>=1.0.2,<=1.0.4)", "sphinxcontrib-devhelp (==1.0.2)", "sphinxcontrib-htmlhelp (>=2.0.0,<=2.0.1)", "sphinxcontrib-qthelp (==1.0.3)", "sphinxcontrib-serializinghtml (==1.1.5)"]
+test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions"]
+
+[[package]]
 name = "idna"
 version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -613,7 +645,6 @@ optional = false
 python-versions = ">=3.9"
 files = [
     {file = "pandas-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:90c6fca2acf139569e74e8781709dccb6fe25940488755716d1d354d6bc58bce"},
-    {file = "pandas-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c7adfc142dac335d8c1e0dcbd37eb8617eac386596eb9e1a1b77791cf2498238"},
     {file = "pandas-2.2.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4abfe0be0d7221be4f12552995e58723c7422c80a659da13ca382697de830c08"},
     {file = "pandas-2.2.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8635c16bf3d99040fdf3ca3db669a7250ddf49c55dc4aa8fe0ae0fa8d6dcc1f0"},
     {file = "pandas-2.2.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:40ae1dffb3967a52203105a077415a86044a2bea011b5f321c6aa64b379a3f51"},
@@ -634,7 +665,6 @@ files = [
     {file = "pandas-2.2.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:43498c0bdb43d55cb162cdc8c06fac328ccb5d2eabe3cadeb3529ae6f0517c32"},
     {file = "pandas-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:d187d355ecec3629624fccb01d104da7d7f391db0311145817525281e2804d23"},
     {file = "pandas-2.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0ca6377b8fca51815f382bd0b697a0814c8bda55115678cbc94c30aacbb6eff2"},
-    {file = "pandas-2.2.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9057e6aa78a584bc93a13f0a9bf7e753a5e9770a30b4d758b8d5f2a62a9433cd"},
     {file = "pandas-2.2.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:001910ad31abc7bf06f49dcc903755d2f7f3a9186c0c040b827e522e9cef0863"},
     {file = "pandas-2.2.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66b479b0bd07204e37583c191535505410daa8df638fd8e75ae1b383851fe921"},
     {file = "pandas-2.2.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a77e9d1c386196879aa5eb712e77461aaee433e54c68cf253053a73b7e49c33a"},
@@ -1038,6 +1068,17 @@ files = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.1"
+description = "A pure Python implementation of a sliding window memory map manager"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "smmap-5.0.1-py3-none-any.whl", hash = "sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da"},
+    {file = "smmap-5.0.1.tar.gz", hash = "sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62"},
+]
+
+[[package]]
 name = "structlog"
 version = "23.3.0"
 description = "Structured Logging for Python"
@@ -1128,4 +1169,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.0,<3.10.0"
-content-hash = "39945440618305817d85e81e3a514d74e1b1c0adbbcd90bb06730adbf86ef57e"
+content-hash = "ceab467437b107efd8626520b89722de2a807e9b5501f9b6fb8a1a416e6ffc05"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ pandas = "^2.2.1"
 unidecode = "^1.3.8"
 xmltodict = "^0.13.0"
 dpytools = {git = "https://github.com/ONSdigital/dp-python-tools.git", tag = "v0.4.0"}
+gitpython = "^3.1.43"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.4"

--- a/tests/pipelines/pipeline/shared/pipelineconfig/test_matching.py
+++ b/tests/pipelines/pipeline/shared/pipelineconfig/test_matching.py
@@ -66,6 +66,7 @@ def test_get_matching_pattern_single_match():
     assert len(results) == 1
     assert set(results) == {"^data.xml$"}
 
+
 def test_get_matching_pattern_supplementary_distributions():
     """
     Ensures get_matching_pattern can correctly return expected matched results from a config when the given pattern is "supplementary_distributions".

--- a/tests/pipelines/pipeline/shared/test_utils.py
+++ b/tests/pipelines/pipeline/shared/test_utils.py
@@ -1,0 +1,13 @@
+import subprocess
+
+from dpypelines.pipeline.shared.utils import get_commit_id
+
+
+def test_get_commit_id():
+    git_cli_commit_hash = (
+        subprocess.check_output(["git", "log", "-1", "--format=%H"])
+        .strip()
+        .decode("utf-8")
+    )
+    utils_commit_hash = get_commit_id()
+    assert git_cli_commit_hash == utils_commit_hash


### PR DESCRIPTION
### What

Glue job was failing due to the Git CLI not being installed inside the Glue job runner. Used `GitPython` library to get the commit hash of the current head. Test added.

### How to review

Run one of the ingress functions with `DISABLE_NOTIFICATIONS` set to false, and check that the commit hash is included in the Slack notification. 

### Who can review

Anyone.