### PR TITLE
Updated dpytools to v0.4.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -417,7 +417,7 @@ websockets = ["websocket-client (>=1.3.0)"]
 
 [[package]]
 name = "dpytools"
-version = "0.4.0"
+version = "0.4.1"
 description = "Simple reusable python resources for digital publishing"
 optional = false
 python-versions = ">=3.9, <3.12"
@@ -435,8 +435,8 @@ structlog = "^23.2.0"
 [package.source]
 type = "git"
 url = "https://github.com/ONSdigital/dp-python-tools.git"
-reference = "v0.4.0"
-resolved_reference = "3527fe9353e4a9b02ee1d75d89ed6bf8d0ff10b0"
+reference = "v0.4.1"
+resolved_reference = "5f7155128d6e55a012259e8a94b04a52e6a0e44f"
 
 [[package]]
 name = "email-validator"
@@ -1189,4 +1189,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.0,<3.10.0"
-content-hash = "ceab467437b107efd8626520b89722de2a807e9b5501f9b6fb8a1a416e6ffc05"
+content-hash = "a77f46b115664fb62c287b6ebb2b6569f8f4de57cc9972739dc31aeac1f62b01"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ python = ">=3.9.0,<3.10.0"
 pandas = "^2.2.1"
 unidecode = "^1.3.8"
 xmltodict = "^0.13.0"
-dpytools = {git = "https://github.com/ONSdigital/dp-python-tools.git", tag = "v0.4.0"}
+dpytools = {git = "https://github.com/ONSdigital/dp-python-tools.git", tag = "v0.4.1"}
 gitpython = "^3.1.43"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/pipelines/pipeline/shared/test_notification.py
+++ b/tests/pipelines/pipeline/shared/test_notification.py
@@ -2,13 +2,13 @@ from unittest.mock import MagicMock
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from dpytools.logging.utility import get_commit_ID
 
 from dpypelines.pipeline.shared.notification import (
     NopNotifier,
     PipelineNotifier,
     notifier_from_env_var_webhook,
 )
+from dpypelines.pipeline.shared.utils import get_commit_id
 
 
 def test_notification_constructor():
@@ -74,7 +74,7 @@ def test_notification_custom_postfix_success():
     notifier.success()
 
     notifier.client.msg_str.assert_called_once_with(
-        f":white_check_mark: {postfix_str}, commit ID: {get_commit_ID()}"
+        f":white_check_mark: {postfix_str}, commit ID: {get_commit_id()}"
     )
 
 
@@ -94,5 +94,5 @@ def test_notification_custom_postfix_failure():
     notifier.failure()
 
     notifier.client.msg_str.assert_called_once_with(
-        f":x: {postfix_str}, commit ID: {get_commit_ID()}"
+        f":x: {postfix_str}, commit ID: {get_commit_id()}"
     )


### PR DESCRIPTION
### What

`get_commit_id()` function removed from dpytools in v0.4.1. 

### How to review

Sanity check

### Who can review

Anyone.