### PR TITLE
feat(config): Add class for loading configuration

### DIFF
--- a/dpypelines/pipeline/config/__init__.py
+++ b/dpypelines/pipeline/config/__init__.py
@@ -1,0 +1,5 @@
+from .job_configuration import JobConfiguration
+from .secret_config import SecretConfig
+from .secret_mapping import SecretMapping
+
+__ALL__ = [JobConfiguration, SecretConfig, SecretMapping]

--- a/dpypelines/pipeline/config/job_configuration.py
+++ b/dpypelines/pipeline/config/job_configuration.py
@@ -1,0 +1,204 @@
+import os
+from typing import List, Optional
+
+from dpytools.logging.logger import DpLogger
+from dpytools.secrets.secret import Secret
+from dpytools.secrets.secrets_client import SecretsClient
+from dpytools.utilities.utilities import str_to_bool
+
+from dpypelines.pipeline.config.secret_config import SecretConfig
+from dpypelines.pipeline.config.secret_mapping import SecretMapping
+
+
+def get_secret_name() -> str:
+    return f"dp-{os.environ.get('ENVIRONMENT', 'sandbox')}-secrets"
+
+
+logger = DpLogger("data-ingress-pipeline")
+
+"""
+Secrets to retrieve from AWS Secrets Manager
+"""
+secrets_config = [
+    SecretConfig(
+        secret_id=get_secret_name(),
+        mappings=[
+            SecretMapping("DATASET_API_URL", "dataset_api_url"),
+            SecretMapping("UPLOAD_SERVICE_URL", "upload_service_url"),
+            SecretMapping("DE_SLACK_WEBHOOK", "de_slack_webhook"),
+            SecretMapping("SERVICE_TOKEN_FOR_UPLOAD", "service_token_for_upload"),
+            SecretMapping("SES_EMAIL_IDENTITY", "ses_email_identity"),
+            SecretMapping(
+                "LAMBDA_FAILURE_SLACK_WEBHOOK", "lambda_failure_slack_webhook"
+            ),
+        ],
+    )
+]
+
+"""
+Environment variables to retrieve
+"""
+environment_variables_config = [
+    # Environment var name, JobConfiguration attribute, default value
+    ("SKIP_DATA_UPLOAD", "skip_data_upload", False),
+    ("DISABLE_NOTIFICATIONS", "disable_notifications", False),
+    ("DISABLE_EMAILS", "disable_emails", False),
+]
+
+
+class JobConfiguration:
+    """
+    Retrieve and store configuration settings for the Glue job.
+    """
+
+    loaded: bool = False
+    error: Optional[str] = None
+
+    dataset_api_url: Optional[str] = None
+    upload_service_url: Optional[str] = None
+    de_slack_webhook: Optional[str] = None
+    service_token_for_upload: Optional[str] = None
+    ses_email_identity: Optional[str] = None
+    lambda_failure_slack_webhook: Optional[str] = None
+
+    skip_data_upload: Optional[bool] = None
+    disable_notifications: Optional[bool] = None
+    disable_emails: Optional[bool] = None
+
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = object.__new__(cls)
+
+        return cls._instance
+
+    def __init__(
+        self,
+        secrets_config: List[tuple] = secrets_config,
+        environment_config: List[tuple] = environment_variables_config,
+        secrets_client: Optional[SecretsClient] = None,
+    ):
+        self.secrets_client = (
+            secrets_client if secrets_client is not None else SecretsClient()
+        )
+        self.secrets_config = secrets_config
+        self.environment_config = environment_config
+        self.load_config()
+
+    def load_config(self, reload: bool = False) -> Optional[str]:
+        """
+        Load config variables
+
+        Args:
+            reload: Force reloading of config
+        :return: Error message (if any)
+        """
+        if self.loaded and not reload:
+            return
+
+        logger.info("Loading JobConfiguration config")
+
+        error = self._load_secrets()
+        if error is not None:
+            self.error = error
+            self.loaded = True
+            logger.error(f"Error loading secrets: {self.error}", error=Exception(error))
+            return error
+
+        self._load_env_vars()
+
+        self.export_env_vars()
+        self.loaded = True
+        logger.info("Loaded JobConfiguration config")
+
+    def export_env_vars(self):
+        os.environ["SERVICE_TOKEN_FOR_UPLOAD"] = self.service_token_for_upload
+
+    def _load_env_vars(self):
+        """
+        Loads config variables from environment vars
+        """
+        logger.info("Setting JobConfiguration values from environment variables")
+        for name, attribute, default_value in self.environment_config:
+            self._load_environment_variable(name, attribute, default_value)
+
+    def _load_secrets(self) -> Optional[str]:
+        """
+        Loads config variables from AWS Secrets
+
+        :return: Error message if any
+        """
+        logger.info("Setting JobConfiguration values from secrets")
+        for secret_config in self.secrets_config:
+            error = self._load_secret(secret_config)
+
+            if error is not None:
+                return error
+
+        return None
+
+    def _set_values_from_secret(
+        self, secret: Secret, secret_mapping: List[SecretMapping]
+    ) -> Optional[str]:
+        """
+        Set various attributes based on the value of the secret
+        :return: Error message if any
+        """
+        if secret.value is None or not isinstance(secret.value, dict):
+            raise ValueError("Expected secret to be a dictionary but it is not.")
+
+        for mapping in secret_mapping:
+            value = secret.value.get(mapping.secret_key, None)
+            self.__setattr__(mapping.config_attribute, value)
+
+    def _load_secret(self, secret_config: SecretConfig) -> Optional[str]:
+        """
+        Load a secret from AWS Secrets Manager and set the appropriate attribute of the
+        JobConfiguration instance.
+
+        :param secret_name: Secret name/ID to retrieve
+        :param class_attribute: Attribute of JobConfiguration that the secret should be set to
+
+        :return: Error message if any
+        """
+        response = self.secrets_client.get_secret(secret_config.secret_id)
+        if (
+            response is None
+            or not response.success
+            or response.error is not None
+            or response.value is None
+        ):
+            return (
+                response.error
+                if response.error is not None
+                else f"An unknown error occurred retrieving {secret_config.secret_id}"
+            )
+
+        if secret_config.config_attribute is not None:
+            self.__setattr__(secret_config.config_attribute, response.value)
+
+        if secret_config.mappings is not None:
+            self._set_values_from_secret(response, secret_config.mappings)
+
+    def _load_environment_variable(
+        self, variable_name: str, class_attribute: str, default_value: Optional[str]
+    ):
+        """
+        Load a variable from the OS env settings and set the appropriate attribute of the
+        JobConfiguration instance.
+
+        :param variable_name: OS environment variable key
+        :param class_attribute: Attribute of JobConfiguration that the secret should be set to
+        """
+        default = default_value
+        if default is not None:
+            default = default_value.__str__()
+
+        value = os.environ.get(variable_name, default)
+
+        if default is not None:
+            if isinstance(default_value, bool):
+                value = str_to_bool(value)
+
+        self.__setattr__(class_attribute, value)

--- a/dpypelines/pipeline/config/secret_config.py
+++ b/dpypelines/pipeline/config/secret_config.py
@@ -1,0 +1,22 @@
+from typing import List, Optional
+
+from dpypelines.pipeline.config.secret_mapping import SecretMapping
+
+
+class SecretConfig:
+    def __init__(
+        self,
+        secret_id: str,
+        config_attribute: Optional[str] = None,
+        mappings: Optional[List[SecretMapping]] = None,
+    ):  # noqa: F821
+        """
+        Configuration for _a single AWS Secret Manager_ and how it maps to the JobConfiguration class
+
+        :param secret_id: The ID/name of the secret in AWS Secrets Manager
+        :param config_attribute: The attribute in JobConfiguration to store the raw secret value
+        :param mappings: List of tuples mappings for a JSON secret
+        """
+        self.secret_id = secret_id
+        self.config_attribute = config_attribute
+        self.mappings = mappings

--- a/dpypelines/pipeline/config/secret_mapping.py
+++ b/dpypelines/pipeline/config/secret_mapping.py
@@ -1,0 +1,10 @@
+class SecretMapping:
+    def __init__(self, secret_key: str, config_attribute: str):
+        """
+        Initialize a new secret mapping
+
+        :param secret_key: The key in the secret value dictionary
+        :param config_attribute: The attribute name in JobConfiguration to set
+        """
+        self.secret_key = secret_key
+        self.config_attribute = config_attribute

--- a/dpypelines/pipeline/messages/notification.py
+++ b/dpypelines/pipeline/messages/notification.py
@@ -7,7 +7,6 @@ from dpypelines.pipeline.messages.utils import (
     get_commit_id,
     get_environment,
     get_local_time,
-    str_to_bool,
 )
 
 
@@ -72,27 +71,3 @@ class PipelineNotifier(BasePipelineNotifier):
     # only present while we're using the temporary "everything worked" message
     def msg_str(self, msg: str):
         self.client.msg_str(msg)
-
-
-def notifier_from_env_var_webhook(
-    env_var: str, process_start_time=None
-) -> BasePipelineNotifier:
-    """
-    Create a variant of BasePipelineMessenger by passing in the name
-    of an envionrment variable that will hold the required webhook.
-    """
-
-    notifications_disabled = os.environ.get("DISABLE_NOTIFICATIONS", None)
-    notifications_disabled = (
-        False if notifications_disabled is None else str_to_bool(notifications_disabled)
-    )
-
-    if notifications_disabled is True:
-        return NopNotifier()
-
-    web_hook = os.environ.get(env_var, None)
-    assert (
-        web_hook is not None
-    ), f"The specified env var {env_var} is not present on this system."
-
-    return PipelineNotifier(web_hook, process_start_time)

--- a/dpypelines/pipeline/messages/utils.py
+++ b/dpypelines/pipeline/messages/utils.py
@@ -7,6 +7,8 @@ from dpytools.email.ses.client import SesClient
 from dpytools.utilities.utilities import str_to_bool
 from email_validator import EmailNotValidError, validate_email
 
+from dpypelines.pipeline.config import JobConfiguration
+
 MIMETYPES = {
     ".csv": "text/csv",
     ".xml": "application/xml",
@@ -25,16 +27,21 @@ def get_email_client():
     """
     Creates an email client object to be used for sending notification/error report emails.
     """
-    emails_disabled = os.environ.get("DISABLE_EMAILS", "True")
+    emails_disabled = str(JobConfiguration().disable_emails)
     emails_disabled = str_to_bool(emails_disabled)
 
     if emails_disabled:
         return NopEmailClient()
 
-    ses_email_identity = os.environ["SES_EMAIL_IDENTITY"]
-    email_client = SesClient(ses_email_identity, "eu-west-2")
+    ses_email_identity = JobConfiguration().ses_email_identity
+    if ses_email_identity:
+        email_client = SesClient(ses_email_identity, "eu-west-2")
 
-    return email_client
+        return email_client
+    else:
+        raise ValueError(
+            "Failed to create email client, ses_email_identity could not be found."
+        )
 
 
 def get_submitter_email(manifest_dict: dict) -> str:

--- a/dpypelines/pipeline/utils.py
+++ b/dpypelines/pipeline/utils.py
@@ -10,32 +10,48 @@ from dpytools.logging.logger import DpLogger
 from dpytools.s3.basic import _get_s3_client, upload_local_file_to_s3
 from dpytools.stores.directory.local import LocalDirectoryStore
 
+from dpypelines.pipeline.config import JobConfiguration
 from dpypelines.pipeline.dataset_api import (
     check_dataset_type_is_static,
     get_post_request_values_from_metadata,
 )
 from dpypelines.pipeline.errors import ValidationException
 from dpypelines.pipeline.messages.email_templates import submission_processed_email
-from dpypelines.pipeline.messages.notification import (
-    PipelineNotifier,
-    notifier_from_env_var_webhook,
-)
+from dpypelines.pipeline.messages.notification import NopNotifier, PipelineNotifier
 from dpypelines.pipeline.messages.utils import (
     get_email_client,
     get_local_time,
     get_mimetype,
+    str_to_bool,
 )
 from dpypelines.pipeline.validate_pipeline import validate_pipeline_files
 
 logger = DpLogger("data-ingress-pipelines")
 
 
+def create_notifier(webhook: str, process_start_time=None):
+    """
+    Create a variant of BasePipelineMessenger by passing in a webhook.
+    Enables use of webhooks from the AWS secrets manager rather than env vars.
+    """
+
+    notifications_disabled = str(JobConfiguration().disable_notifications)
+    notifications_disabled = (
+        False if notifications_disabled is None else str_to_bool(notifications_disabled)
+    )
+
+    if notifications_disabled is True:
+        return NopNotifier()
+
+    return PipelineNotifier(webhook, process_start_time)
+
+
 def get_notifier():
     # Create notifier from webhook env var
     try:
         process_start_time = get_local_time()
-        notifier: PipelineNotifier = notifier_from_env_var_webhook(
-            "DE_SLACK_WEBHOOK",
+        notifier: PipelineNotifier = create_notifier(
+            JobConfiguration().de_slack_webhook,
             process_start_time=process_start_time,
         )
         logger.info("Notifier created", data={"notifier": notifier})
@@ -283,9 +299,9 @@ def upload_metadata(metadata) -> bool:
     """
     Upload metadata to the Dataset API.
     """
-    dataset_api_url = os.environ.get("DATASET_API_URL")
+    dataset_api_url = JobConfiguration().dataset_api_url
     if not dataset_api_url:
-        msg = "Required environment variable not set: DATASET_API_URL"
+        msg = "Required variable not set: DATASET_API_URL"
         raise EnvironmentError(msg)
 
     # Generate POST request body from metadata
@@ -320,12 +336,14 @@ def upload_metadata(metadata) -> bool:
 
 
 def upload_files(files_to_upload):
-    """
-    Upload data files to the Upload Service.
-    """
-    upload_url = os.environ.get("UPLOAD_SERVICE_URL")
-    if not upload_url:
-        err_msg = "Required environment variable not set: UPLOAD_SERVICE_URL."
+    """Upload files and send notifications."""
+    upload_url = JobConfiguration().upload_service_url
+    dataset_api_url = JobConfiguration().dataset_api_url
+    if not upload_url or not dataset_api_url:
+        err_msg = (
+            f"Required variables not set: "
+            f"UPLOAD_SERVICE_URL: {upload_url}, DATASET_API_URL: {dataset_api_url}."
+        )
         raise EnvironmentError(err_msg)
 
     upload_client = UploadServiceClient(upload_url)

--- a/dpypelines/s3_folder_received.py
+++ b/dpypelines/s3_folder_received.py
@@ -1,8 +1,6 @@
-import os
-
 from dpytools.logging.logger import DpLogger
-from dpytools.utilities.utilities import str_to_bool
 
+from dpypelines.pipeline.config import JobConfiguration
 from dpypelines.pipeline.messages.error_handler_module import error_handler
 from dpypelines.pipeline.utils import (
     copy_s3_processing_folder_to_destination_folder,
@@ -50,7 +48,7 @@ def start(s3_object_name: str, *args, **kwargs):
         validation_results = validate_pipeline(files_dir, pipeline_config)
 
         # Upload metadata to Dataset API.
-        if not str_to_bool(os.environ.get("SKIP_DATA_UPLOAD", "False")):
+        if not JobConfiguration().skip_data_upload:
             metadata_submitted = upload_metadata(
                 validation_results["metadata"],
             )

--- a/tests/pipelines/pipeline/shared/test_notification.py
+++ b/tests/pipelines/pipeline/shared/test_notification.py
@@ -3,40 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
-from dpypelines.pipeline.messages.notification import (
-    NopNotifier,
-    PipelineNotifier,
-    notifier_from_env_var_webhook,
-)
-
-
-def test_notification_constructor():
-    """
-    Test that the PipelineNotifier can be successfully created from
-    a webhook supplied from an env var
-    """
-
-    mp = MonkeyPatch()
-    fake_web_hook = "fake-web-hook"
-    mp.setenv("DISABLE_NOTIFICATIONS", "False")
-    mp.setenv("SOME_ENV_VAR", fake_web_hook)
-
-    norifier = notifier_from_env_var_webhook("SOME_ENV_VAR")
-    assert isinstance(norifier, PipelineNotifier)
-    assert norifier.client.webhook_url == fake_web_hook
-
-
-def test_notification_constructor_with_disabled_notifications():
-    """
-    Tests that a NopNotifier is constructed where DISABLE_NOTIFICATIONS
-    is true
-    """
-
-    mp = MonkeyPatch()
-    mp.setenv("DISABLE_NOTIFICATIONS", "True")
-
-    norifier = notifier_from_env_var_webhook("DOES_NOT_MATTER")
-    assert isinstance(norifier, NopNotifier)
+from dpypelines.pipeline.messages.notification import PipelineNotifier
 
 
 def test_notification_raises_for_missing_webhook():

--- a/tests/pipelines/pipeline/test_job_configuration.py
+++ b/tests/pipelines/pipeline/test_job_configuration.py
@@ -1,0 +1,255 @@
+from importlib import reload
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import dpypelines.pipeline.config.job_configuration
+from dpypelines.pipeline.config import SecretConfig
+from dpypelines.pipeline.config.job_configuration import secrets_config
+
+secrets = {}
+
+expected_secret_name = "dp-sandbox-secrets"
+test_secret_one = SecretConfig("TEST_ONE", "test_attr_one")
+test_secret_two = SecretConfig("OTHER_TEST", "other_test_attr")
+test_secret_config = [*secrets_config, test_secret_one, test_secret_two]
+
+
+def create_test_secret_value(config: SecretConfig):
+    if config.mappings is None:
+        return f"{secret.secret_id} - {secret.config_attribute}"
+
+    value = {}
+
+    for mapping in config.mappings:
+        value[mapping.secret_key] = f"{mapping.config_attribute} - {mapping.secret_key}"
+
+    return value
+
+
+for secret in test_secret_config:
+    secrets[secret.secret_id] = create_test_secret_value(secret)
+
+
+def get_secret(secret_id: str):
+    mock_secret = MagicMock()
+
+    secret_exists = secret_id in secrets
+    if not secret_exists:
+        mock_secret.error = f"Could not find secret {secret_id}"
+        mock_secret.value = None
+        mock_secret.success = False
+    else:
+        mock_secret.error = None
+        mock_secret.value = secrets[secret_id]
+        mock_secret.success = True
+
+    return mock_secret
+
+
+@patch("dpytools.secrets.secrets_client.SecretsClient")
+def test_should_load_config(secrets_client):
+    """
+    Tests that a secrets client can successfully be loaded and a job configuration instance
+    can be created taking a secrets client, environment variables config, and secrets config.
+    The result should raisei no errors, with the contents matching the expected results.
+    """
+    secrets_client.return_value.get_secret.side_effect = get_secret
+
+    reload(dpypelines.pipeline.config.job_configuration)
+    from dpypelines.pipeline.config.job_configuration import JobConfiguration
+
+    mp = pytest.MonkeyPatch()
+
+    mp.setenv("SKIP_DATA_UPLOAD", "True")
+    mp.setenv("DISABLE_NOTIFICATIONS", "True")
+    mp.setenv("DISABLE_EMAILS", "True")
+
+    test_environment_vars_config = [
+        # Environment var name, JobConfiguration attribute, default value
+        ("SKIP_DATA_UPLOAD", "skip_data_upload", True),
+        ("DISABLE_NOTIFICATIONS", "disable_notifications", True),
+        ("DISABLE_EMAILS", "disable_emails", True),
+    ]
+
+    config = JobConfiguration(
+        secrets_config=test_secret_config,
+        environment_config=test_environment_vars_config,
+        secrets_client=secrets_client(),
+    )
+
+    assert config.loaded
+    assert config.error is None
+
+    for secret_config in secrets_config:
+        secret = secrets[secret_config.secret_id]
+        if secret_config.config_attribute is not None:
+            assert config.__getattribute__(secret_config.config_attribute) == secret
+        else:
+            for mapping in secret_config.mappings:
+                assert (
+                    config.__getattribute__(mapping.config_attribute)
+                    == secret[mapping.secret_key]
+                )
+
+    assert config.disable_emails
+    assert config.disable_notifications
+    assert config.skip_data_upload
+
+
+@patch("dpytools.secrets.secrets_client.SecretsClient")
+def test_should_load_secrets_from_constructor(secrets_client):
+    """
+    Tests that a secrets job configuration can load secrets when given a secrets client
+    and config as input, and the results are as expected.
+    """
+    secrets_client.return_value.get_secret.side_effect = get_secret
+
+    reload(dpypelines.pipeline.config.job_configuration)
+    from dpypelines.pipeline.config.job_configuration import JobConfiguration
+
+    config = JobConfiguration(
+        secrets_client=secrets_client(), secrets_config=test_secret_config
+    )
+    error = config.load_config()
+
+    assert error is None
+    assert config.loaded
+    assert config.error is None
+
+    assert config.test_attr_one == secrets[test_secret_one.secret_id]
+    assert config.other_test_attr == secrets[test_secret_two.secret_id]
+
+
+@patch("dpytools.secrets.secrets_client.SecretsClient")
+def test_should_load_env_vars_from_constructor(secrets_client):
+    """
+    Tests that a job configuration can be created taking an environment
+    variables config as input, with the results raising no errors and
+    matching expected results.
+    """
+    secrets_client.return_value.get_secret.side_effect = get_secret
+
+    reload(dpypelines.pipeline.config.job_configuration)
+    from dpypelines.pipeline.config.job_configuration import JobConfiguration
+
+    # First tuple element == the environment variable config
+    # Second tuple element == value to set environment var to
+    # Third == what we expect final result to be
+    value_set_and_default_value = (
+        ("FIRST_ENV_KEY", "env_attr_one", True),
+        "False",
+        False,
+    )
+    value_set_and_no_default_value = (
+        ("OTHER_ENV_KEY", "env_attr_two", None),
+        "False",
+        "False",
+    )  # No default value is set so does not know to parse as bool
+    value_not_set_with_default_value = (
+        ("ENV_KEY", "env_attr_three", "default value"),
+        None,
+        "default value",
+    )
+    value_not_set_with_no_default = (
+        ("FINAL_ENV_KEY", "env_attr_four", None),
+        None,
+        None,
+    )
+
+    # Just the above
+    test_env_vars = [
+        value_set_and_default_value,
+        value_set_and_no_default_value,
+        value_not_set_with_default_value,
+        value_not_set_with_no_default,
+    ]
+
+    test_env_config = [item[0] for item in test_env_vars]
+
+    mp = pytest.MonkeyPatch()
+
+    for env_config, env_value, expected_value in test_env_vars:
+        if env_value is not None:
+            mp.setenv(env_config[0], env_value)
+
+    config = JobConfiguration(
+        secrets_client=secrets_client(), environment_config=test_env_config
+    )
+    error = config.load_config()
+
+    assert error is None
+    assert config.loaded
+    assert config.error is None
+
+    for env_config, env_value, expected_value in test_env_vars:
+        assert config.__getattribute__(env_config[1]) == expected_value
+
+    assert config.env_attr_one == value_set_and_default_value[2]
+    assert config.env_attr_two == value_set_and_no_default_value[2]
+    assert config.env_attr_three == value_not_set_with_default_value[2]
+    assert config.env_attr_four == value_not_set_with_no_default[2]
+
+
+@patch("dpytools.secrets.secrets_client.SecretsClient")
+def test_should_exits_on_secret_error(secrets_client, monkeypatch):
+    """ """
+    secrets_client.return_value.get_secret.side_effect = get_secret
+
+    missing_secret = SecretConfig("THIS_SECRET_DOESNT_EXIST", "attr_should_not_be_set")
+    secrets_with_missing = [*secrets_config, missing_secret]
+
+    monkeypatch.setenv("SKIP_DATA_UPLOAD", "True")
+    monkeypatch.setenv("DISABLE_NOTIFICATIONS", "True")
+    monkeypatch.setenv("DISABLE_EMAILS", "True")
+
+    reload(dpypelines.pipeline.config.job_configuration)
+    from dpypelines.pipeline.config.job_configuration import JobConfiguration
+
+    config = JobConfiguration(
+        secrets_client=secrets_client(), secrets_config=secrets_with_missing
+    )
+
+    assert config.error is not None
+    assert config.loaded
+
+    # Should not exist
+    with pytest.raises(AttributeError):
+        config.__getattribute__(missing_secret.secret_id)
+
+    # Since the missing secret was _last_ in the list, this _should_ exist
+    assert config.dataset_api_url is not None
+
+    # But these should be None since they will not have been retrieved:
+    assert config.disable_emails is None
+    assert config.disable_notifications is None
+    assert config.skip_data_upload is None
+
+
+@patch("dpytools.secrets.secrets_client.SecretsClient")
+def test_should_exits_early_on_secret_error(secrets_client):
+    """ """
+    reload(dpypelines.pipeline.config.job_configuration)
+    from dpypelines.pipeline.config.job_configuration import JobConfiguration
+
+    secrets_client.return_value.get_secret.side_effect = get_secret
+
+    missing_secret = SecretConfig("THIS_SECRET_DOESNT_EXIST", "attr_should_not_be_set")
+    secrets_with_missing = [
+        missing_secret,
+        *secrets_config,
+    ]
+
+    config = JobConfiguration(
+        secrets_client=secrets_client(), secrets_config=secrets_with_missing
+    )
+
+    assert config.error is not None
+    assert config.loaded
+
+    # Should not exist
+    with pytest.raises(AttributeError):
+        config.__getattribute__(missing_secret.secret_id)
+
+    # Since the missing secret was _first_ in the list, this _should not_ exist as we should have already exited
+    assert config.dataset_api_url is None

--- a/tests/pipelines/pipeline/test_pipeline_utils.py
+++ b/tests/pipelines/pipeline/test_pipeline_utils.py
@@ -87,25 +87,27 @@ def test_validate_pipeline(mock_validate_pipeline_files):
     assert validation_results == mock_validation_results
 
 
+@patch("dpypelines.pipeline.utils.JobConfiguration")
 @patch("dpypelines.pipeline.utils.UploadServiceClient")
 @patch("dpypelines.pipeline.utils.get_mimetype")
-def test_upload_files(mock_get_mimetype, mock_UploadServiceClient):
+def test_upload_files(mock_get_mimetype, mock_UploadServiceClient, mock_job_config):
     """Test that `upload_files()` uploads the files and sends the email."""
     mock_validation_results = {"config_files": ["file1", "file2"]}
     mock_upload_client = MagicMock()
+    mock_job_configuration = MagicMock()
+
+    upload_url = "http://upload.url"
+    dataset_api_url = "http://datasetapi.url"
+    mock_job_configuration.upload_service_url = upload_url
+    mock_job_configuration.dataset_api_url = dataset_api_url
 
     mock_get_mimetype.return_value = "text/csv"
     mock_UploadServiceClient.return_value = mock_upload_client
+    mock_job_config.return_value = mock_job_configuration
 
-    with patch.dict(
-        os.environ,
-        {
-            "UPLOAD_SERVICE_URL": "http://upload.url",
-        },
-    ):
-        upload_files(mock_validation_results)
+    upload_files(mock_validation_results)
 
-    mock_UploadServiceClient.assert_called_once_with("http://upload.url")
+    mock_UploadServiceClient.assert_called_once_with(upload_url)
     mock_get_mimetype.assert_called()
     mock_upload_client.upload_new.assert_called()
 
@@ -560,16 +562,24 @@ def test_process_zip_file_errors_when_no_files(
     )
 
 
+@patch("dpypelines.pipeline.utils.JobConfiguration")
 @patch("dpypelines.pipeline.utils.check_dataset_type_is_static")
 @patch("dpypelines.pipeline.utils.get_post_request_values_from_metadata")
 @patch("dpypelines.pipeline.utils.DatasetAPIClient")
 def test_upload_metadata_succeeds(
-    mock_DatasetAPIClient, mock_request_values, mock_dataset_type
+    mock_DatasetAPIClient, mock_request_values, mock_dataset_type, mock_job_config
 ):
     mock_dataset_api_client = MagicMock()
     mock_DatasetAPIClient.return_value = mock_dataset_api_client
     mock_dataset_api_client.get_path.return_value.status_code = 200
     mock_dataset_api_client.post_json.return_value.status_code = 201
+
+    mock_job_configuration = MagicMock()
+
+    upload_url = "http://upload.url"
+    dataset_api_url = "http://dataset-api.url"
+    mock_job_configuration.upload_service_url = upload_url
+    mock_job_configuration.dataset_api_url = dataset_api_url
 
     mock_request_values.return_value = (
         "dataset_path",
@@ -579,14 +589,9 @@ def test_upload_metadata_succeeds(
     mock_dataset_type.return_value = True
     with open("tests/fixtures/test-cases/test_metadata.json") as f:
         metadata = json.load(f)
+    mock_job_config.return_value = mock_job_configuration
 
-    with patch.dict(
-        os.environ,
-        {
-            "DATASET_API_URL": "http://dataset-api.url",
-        },
-    ):
-        metadata_uploaded = upload_metadata(metadata)
+    metadata_uploaded = upload_metadata(metadata)
 
     mock_DatasetAPIClient.assert_called_once_with(
         "http://dataset-api.url", "dataset_path", "edition_path"
@@ -598,15 +603,23 @@ def test_upload_metadata_succeeds(
     assert metadata_uploaded
 
 
+@patch("dpypelines.pipeline.utils.JobConfiguration")
 @patch("dpypelines.pipeline.utils.check_dataset_type_is_static")
 @patch("dpypelines.pipeline.utils.get_post_request_values_from_metadata")
 @patch("dpypelines.pipeline.utils.DatasetAPIClient")
 def test_upload_metadata_fails_not_static(
-    mock_DatasetAPIClient, mock_request_values, mock_dataset_type
+    mock_DatasetAPIClient, mock_request_values, mock_dataset_type, mock_job_config
 ):
     mock_dataset_api_client = MagicMock()
     mock_DatasetAPIClient.return_value = mock_dataset_api_client
     mock_dataset_api_client.get_path.return_value.status_code = 200
+
+    mock_job_configuration = MagicMock()
+
+    upload_url = "http://upload.url"
+    dataset_api_url = "http://dataset-api.url"
+    mock_job_configuration.upload_service_url = upload_url
+    mock_job_configuration.dataset_api_url = dataset_api_url
 
     mock_request_values.return_value = (
         "dataset_path",
@@ -617,13 +630,9 @@ def test_upload_metadata_fails_not_static(
     with open("tests/fixtures/test-cases/test_metadata.json") as f:
         metadata = json.load(f)
 
-    with patch.dict(
-        os.environ,
-        {
-            "DATASET_API_URL": "http://dataset-api.url",
-        },
-    ):
-        metadata_uploaded = upload_metadata(metadata)
+    mock_job_config.return_value = mock_job_configuration
+
+    metadata_uploaded = upload_metadata(metadata)
 
     mock_DatasetAPIClient.assert_called_once_with(
         "http://dataset-api.url", "dataset_path", "edition_path"
@@ -634,15 +643,23 @@ def test_upload_metadata_fails_not_static(
     assert not metadata_uploaded
 
 
+@patch("dpypelines.pipeline.utils.JobConfiguration")
 @patch("dpypelines.pipeline.utils.check_dataset_type_is_static")
 @patch("dpypelines.pipeline.utils.get_post_request_values_from_metadata")
 @patch("dpypelines.pipeline.utils.DatasetAPIClient")
 def test_upload_metadata_fails_get_path_404(
-    mock_DatasetAPIClient, mock_request_values, mock_dataset_type
+    mock_DatasetAPIClient, mock_request_values, mock_dataset_type, mock_job_config
 ):
     mock_dataset_api_client = MagicMock()
     mock_DatasetAPIClient.return_value = mock_dataset_api_client
     mock_dataset_api_client.get_path.return_value.status_code = 404
+
+    mock_job_configuration = MagicMock()
+
+    upload_url = "http://upload.url"
+    dataset_api_url = "http://dataset-api.url"
+    mock_job_configuration.upload_service_url = upload_url
+    mock_job_configuration.dataset_api_url = dataset_api_url
 
     mock_request_values.return_value = (
         "dataset_path",
@@ -653,13 +670,9 @@ def test_upload_metadata_fails_get_path_404(
     with open("tests/fixtures/test-cases/test_metadata.json") as f:
         metadata = json.load(f)
 
-    with patch.dict(
-        os.environ,
-        {
-            "DATASET_API_URL": "http://dataset-api.url",
-        },
-    ):
-        upload_metadata(metadata)
+    mock_job_config.return_value = mock_job_configuration
+
+    upload_metadata(metadata)
 
     mock_DatasetAPIClient.assert_called_once_with(
         "http://dataset-api.url", "dataset_path", "edition_path"

--- a/tests/pipelines/pipeline/test_s3_folder_received.py
+++ b/tests/pipelines/pipeline/test_s3_folder_received.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -7,6 +6,7 @@ import pytest
 from dpypelines.s3_folder_received import start
 
 
+@patch("dpypelines.s3_folder_received.JobConfiguration")
 @patch("dpypelines.s3_folder_received.delete_s3_processing_folder")
 @patch("dpypelines.s3_folder_received.copy_s3_processing_folder_to_destination_folder")
 @patch("dpypelines.s3_folder_received.upload_metadata")
@@ -24,7 +24,9 @@ def test_start_succeeds(
     mock_upload_metadata,
     mock_copy_s3_processing,
     mock_delete_s3_processing,
+    mock_job_config,
 ):
+
     mock_notifier, mock_email_client = (
         MagicMock(name="notifier"),
         MagicMock(name="email_client"),
@@ -50,15 +52,16 @@ def test_start_succeeds(
     }
     mock_upload_metadata.return_value = True
     mock_copy_s3_processing.return_value = "processed/timestamp-files"
+    mock_job_configuration = MagicMock()
 
-    with patch.dict(
-        os.environ,
-        {
-            "DATASET_API_URL": "http://dataset-api.url",
-            "UPLOAD_SERVICE_URL": "http://upload-service.url",
-        },
-    ):
-        start("dummy_s3_object_name")
+    upload_url = "http://upload.url"
+    dataset_api_url = "http://datasetapi.url"
+    mock_job_configuration.upload_service_url = upload_url
+    mock_job_configuration.dataset_api_url = dataset_api_url
+    mock_job_configuration.skip_data_upload = False
+    mock_job_config.return_value = mock_job_configuration
+
+    start("dummy_s3_object_name")
 
     mock_setup_clients.assert_called_once()
     mock_process_zip_file.assert_called_once_with("dummy_s3_object_name")
@@ -78,6 +81,7 @@ def test_start_succeeds(
     )
 
 
+@patch("dpypelines.s3_folder_received.JobConfiguration")
 @patch("dpypelines.s3_folder_received.delete_s3_processing_folder")
 @patch("dpypelines.s3_folder_received.copy_s3_processing_folder_to_destination_folder")
 @patch("dpypelines.s3_folder_received.upload_metadata")
@@ -93,6 +97,7 @@ def test_start_fails_dataset_not_static(
     mock_upload_metadata,
     mock_copy_s3_processing,
     mock_delete_s3_processing,
+    mock_job_config,
 ):
     mock_notifier, mock_email_client = (
         MagicMock(name="notifier"),
@@ -120,14 +125,16 @@ def test_start_fails_dataset_not_static(
     mock_upload_metadata.return_value = False
     mock_copy_s3_processing.return_value = "processed/timestamp-files"
 
-    with patch.dict(
-        os.environ,
-        {
-            "DATASET_API_URL": "http://dataset-api.url",
-            "UPLOAD_SERVICE_URL": "http://upload-service.url",
-        },
-    ):
-        start("dummy_s3_object_name")
+    mock_job_configuration = MagicMock()
+
+    upload_url = "http://upload.url"
+    dataset_api_url = "http://datasetapi.url"
+    mock_job_configuration.upload_service_url = upload_url
+    mock_job_configuration.dataset_api_url = dataset_api_url
+    mock_job_configuration.skip_data_upload = False
+    mock_job_config.return_value = mock_job_configuration
+
+    start("dummy_s3_object_name")
 
     mock_setup_clients.assert_called_once()
     mock_process_zip_file.assert_called_once_with("dummy_s3_object_name")


### PR DESCRIPTION
pending:

- Documentation

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Adds a class for loading configuration variables for the Glue job, from AWS Secrets Manager + environment variables.

Also replaces all the instances of `os.environ.get("ETC")` with this so relevant information is now being retrieved from the secrets manager rather than from environment variables.

Adds a new set of unit tests with some mocking to test the new JobConfiguration class functionality.

The purpose is encapsulate all configuration loading into _one_ place. This way:
1. It is clear where config variables are loaded
2. It is clear _how_ config variables are loaded
3. We only load them once
4. "Strongly" typed class with explict variable names to prevent having to copy and paste keys everywhere

etc.

There is likely some changes to be made around how this and/or the `SecretsClient` work, but for now this should suffice.

### Testing

- [x] Yes
- [ ] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

Unit tests 98%.

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [ ] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

No - I will add before asking for this ticket to be reviewed.

### Related issues

Provide links to any related issues.

### How to review

Describe the steps required to test the changes.