### PR TITLE
cicd: Amend workflows to trigger on PR, not push

### DIFF
--- a/.github/workflows/code_quality.yaml
+++ b/.github/workflows/code_quality.yaml
@@ -1,6 +1,11 @@
 name: Checking Code Quality
 
-on: [push]
+on:
+  pull_request:
+    branches:
+      - sandbox
+      - staging
+      - production
 
 jobs:
   build:

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -1,6 +1,11 @@
 name: Run acceptance tests
 
-on: [push]
+on:
+  pull_request:
+    branches:
+      - sandbox
+      - staging
+      - production
 
 jobs:
   build:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,6 +1,11 @@
 name: Python Unit Tests
 
-on: [push]
+on:
+  pull_request:
+    branches:
+      - sandbox
+      - staging
+      - production
 
 jobs:
   build:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

### What

The existing CI/CD actions trigger on every push to every branch. This is ineffecient and unnecessary. This PR amends it them to only trigger on PRs instead.