### PR TITLE
feat: write to temp folder

### DIFF
--- a/dpypelines/pipeline/utils.py
+++ b/dpypelines/pipeline/utils.py
@@ -74,17 +74,21 @@ def download_zip_file(s3_object_name: str) -> str:
     # Split s3_object_name on final "/" in case of nested directory structure (e.g. <dir1>/dir2>/input.zip)
     input_dir, input_zip_name = object_key.rsplit("/", maxsplit=1)
     # Create a local directory to store downloaded zip file
-    Path(input_dir).mkdir(parents=True, exist_ok=True)
+    Path(f"/tmp/{input_dir}").mkdir(parents=True, exist_ok=True)
+
+    target_path = f"/tmp/{object_key}"
+    logger.info(f'Changed object key from "{object_key}" to "{target_path}"')
 
     # Download S3 object to local directory
     client = _get_s3_client(profile_name=os.environ.get("AWS_PROFILE"))
-    with open(object_key, "wb") as f:
+    with open(target_path, "wb") as f:
         client.download_fileobj(Bucket=bucket_name, Key=object_key, Fileobj=f)
     logger.info(
         "Downloaded zip file to local folder",
         data={"local_input_folder": input_dir, "local_file_name": input_zip_name},
     )
-    return object_key
+
+    return target_path
 
 
 def decompress_zip_file(local_zip_path: str) -> Path:
@@ -93,7 +97,9 @@ def decompress_zip_file(local_zip_path: str) -> Path:
     """
     # Create destination directory to store decompressed files
     _, file_name = local_zip_path.rsplit("/", maxsplit=1)
-    destination_dir = Path(file_name.split(".")[0])
+
+    output_file_path = f"/tmp/{file_name.split('.')[0]}"
+    destination_dir = Path(output_file_path)
     destination_dir.mkdir(parents=True, exist_ok=True)
 
     # Extract zip file to destination directory
@@ -147,7 +153,7 @@ def upload_to_s3_processing_folder(
     # Copy original zip file from S3 input location to S3 "processing" folder
     s3_client.copy_object(
         Bucket=bucket_name,
-        Key=f"{s3_processing_folder}/{local_object_key}",
+        Key=f"{s3_processing_folder}/{local_object_key}".replace("/tmp/", ""),
         CopySource={"Bucket": bucket_name, "Key": s3_object_key},
     )
 

--- a/tests/pipelines/pipeline/test_pipeline_utils.py
+++ b/tests/pipelines/pipeline/test_pipeline_utils.py
@@ -190,9 +190,10 @@ def test_decompress_zip_file_no_files(mock_zipfile, mock_path):
     mock_zipfile.assert_called_once_with(local_zip_path, "r")
     mock_zip_instance.extractall.assert_called_once()
 
-    assert file_name in path_instances
+    expected_folder = f"/tmp/{file_name}"
+    assert expected_folder in path_instances
 
-    mock_destination = path_instances[file_name]
+    mock_destination = path_instances[expected_folder]
     mock_destination.mkdir.assert_called_once_with(parents=True, exist_ok=True)
     mock_destination.rglob.assert_called_with("*")
 
@@ -225,9 +226,10 @@ def test_decompress_zip_file_non_recursive(mock_zipfile, mock_path):
     mock_zipfile.assert_called_once_with(local_zip_path, "r")
     mock_zip_instance.extractall.assert_called_once()
 
-    assert file_name in path_instances
+    expected_folder = f"/tmp/{file_name}"
+    assert expected_folder in path_instances
 
-    mock_destination = path_instances[file_name]
+    mock_destination = path_instances[expected_folder]
     mock_destination.mkdir.assert_called_once_with(parents=True, exist_ok=True)
     mock_destination.rglob.assert_called_with("*")
 
@@ -259,10 +261,10 @@ def test_decompress_zip_file_recursive(mock_zipfile, mock_path):
 
     mock_zipfile.assert_called_once_with(local_zip_path, "r")
     mock_zip_instance.extractall.assert_called_once()
+    expected_folder = f"/tmp/{file_name}"
+    assert expected_folder in path_instances
 
-    assert file_name in path_instances
-
-    mock_destination = path_instances[file_name]
+    mock_destination = path_instances[expected_folder]
     mock_destination.mkdir.assert_called_once_with(parents=True, exist_ok=True)
     mock_destination.rglob.assert_called_with("*")
 
@@ -313,6 +315,7 @@ def test_upload_to_s3_processing_folder(
             None,
         ),
     ]
+
     mock_upload.assert_has_calls(upload_calls, any_order=True)
     mock_s3.copy_object.assert_called_once_with(
         Bucket="bucket",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

- Save all files/folders to a `/tmp` folder on the Lambda file-system

The rest of the file-system is read-only, so any files saved/unzipped/etc. need to be don ein this folder.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

But tests have been amended.

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

Not yet, but there will be some to come. Will work on this as part of a bigger piece of work around tech exec paper for change over to Lambda.

### Related issues

2916