### PR TITLE
feat: Function added to check if dataset type is static

### DIFF
--- a/dpypelines/pipeline/dataset_api.py
+++ b/dpypelines/pipeline/dataset_api.py
@@ -1,0 +1,118 @@
+import json
+from datetime import datetime
+
+from dpytools.http.api.dataset_api_client import DatasetAPIClient
+from dpytools.logging.logger import DpLogger
+
+from dpypelines.pipeline.errors import (
+    DatasetAPIRequestCreationException,
+    DatasetNotFoundException,
+    DatasetTypeException,
+    DistributionsException,
+)
+
+logger = DpLogger("data-ingress-pipelines")
+
+
+def get_post_request_values_from_metadata(metadata: dict):
+    """
+    Generate the required path values and request body to submit to the Dataset API. This will be submitted as a POST request to the endpoint `/datasets/{dataset_path}/editions/{edition_path}/versions`
+    """
+    try:
+        dataset_path = metadata.get("dcterms:identifier", None)
+        editions = metadata.get("TBC:edition", None)
+        if editions is not None:
+            edition: dict = editions[0]
+        else:
+            edition = {"dcterms:identifier": None}
+        edition_path = edition.get("dcterms:identifier", None)
+        metadata_distributions = edition.get("dcat:distribution", None)
+        if metadata_distributions is not None:
+            distributions = get_distribution_details_for_request(metadata_distributions)
+        else:
+            distributions = None
+
+        request_body = {
+            "distributions": distributions,
+            "release_date": datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "edition_title": edition.get("dcterms:title", None),
+            "title": metadata.get("dcterms:title", None),
+            "description": metadata.get("dcterms:description", None),
+            "next_release": metadata.get("TBC:nextRelease", None),
+            "themes": metadata.get("dcat:theme", None),
+            "alerts": edition.get("TBC:alerts", None),
+            "usage_notes": edition.get("TBC:usage_notes", None),
+            "quality_designation": edition.get("TBC:quality_designation", None),
+        }
+        return dataset_path, edition_path, request_body
+    except Exception as err:
+        raise DatasetAPIRequestCreationException(
+            "Error getting POST request values from metadata", metadata=metadata
+        ) from err
+
+
+def get_distribution_details_for_request(metadata_distributions: list) -> list:
+    """
+    Get the information to populate the `distributions` property in the POST request to the Dataset API.
+    """
+    try:
+        distributions = [
+            {
+                "title": distribution["dcterms:title"],
+                "download_url": distribution["download_url"],
+                # TODO Calculate byte_size during processing
+                "byte_size": 0,
+                "format": distribution["TBC:distributionFormat"],
+                "media_type": distribution["dcat:mediaType"],
+            }
+            for distribution in metadata_distributions
+        ]
+        logger.info(
+            "Distributions information retrieved",
+            data={"distributions": distributions},
+        )
+        return distributions
+    except Exception as err:
+        raise DistributionsException(
+            "Error getting details of distributions for Dataset API request",
+            distributions=metadata_distributions,
+        ) from err
+
+
+def get_dataset_api_response(dataset_api_client: DatasetAPIClient) -> dict:
+    get_dataset_result = dataset_api_client.get(
+        f"{dataset_api_client.dataset_api_url}/{dataset_api_client.dataset_path}",
+        headers=dataset_api_client.token_auth.get_auth_header(),
+    )
+    if get_dataset_result.status_code != 200:
+        get_dataset_result.raise_for_status()
+        return
+
+    return json.loads(get_dataset_result.text)
+
+
+def get_current_dataset_type(dataset_result: dict) -> str:
+    current_dataset = dataset_result.get("current", None)
+    if current_dataset:
+        return current_dataset.get("type", None)
+    else:
+        raise KeyError("'current' not found in dataset_result keys")
+
+
+def check_dataset_type_is_static(dataset_api_client: DatasetAPIClient) -> bool:
+    dataset_result = get_dataset_api_response(dataset_api_client)
+    if dataset_result:
+        dataset_type = get_current_dataset_type(dataset_result)
+    else:
+        raise DatasetNotFoundException(
+            "Dataset not found", dataset_path=dataset_api_client.dataset_path
+        )
+
+    if dataset_type and dataset_type == "static":
+        logger.info("Dataset type is static")
+        return True
+    elif dataset_type and dataset_type != "static":
+        logger.info("Dataset type is not static")
+        return False
+    else:
+        raise DatasetTypeException("Dataset type error", dataset_type=str(dataset_type))

--- a/dpypelines/pipeline/errors/__init__.py
+++ b/dpypelines/pipeline/errors/__init__.py
@@ -1,5 +1,13 @@
 from .dataset_api_request_creation_exception import DatasetAPIRequestCreationException
+from .dataset_not_found_exception import DatasetNotFoundException
+from .dataset_type_exception import DatasetTypeException
 from .distributions_exception import DistributionsException
 from .validation_exception import ValidationException
 
-all = [DatasetAPIRequestCreationException, DistributionsException, ValidationException]
+all = [
+    DatasetAPIRequestCreationException,
+    DatasetNotFoundException,
+    DatasetTypeException,
+    DistributionsException,
+    ValidationException,
+]

--- a/dpypelines/pipeline/errors/dataset_not_found_exception.py
+++ b/dpypelines/pipeline/errors/dataset_not_found_exception.py
@@ -1,0 +1,7 @@
+from dpytools.logging.data_exception import DataException
+
+
+class DatasetNotFoundException(DataException):
+    def __init__(self, message: str, dataset_path: str, *args: object):
+        data = {"dataset_path": dataset_path}
+        super().__init__(message, data=data, *args)

--- a/dpypelines/pipeline/errors/dataset_type_exception.py
+++ b/dpypelines/pipeline/errors/dataset_type_exception.py
@@ -1,0 +1,9 @@
+from typing import Optional
+
+from dpytools.logging.data_exception import DataException
+
+
+class DatasetTypeException(DataException):
+    def __init__(self, message: str, dataset_type: Optional[str], *args: object):
+        data = {"dataset_type": dataset_type}
+        super().__init__(message, data=data, *args)

--- a/dpypelines/pipeline/utils.py
+++ b/dpypelines/pipeline/utils.py
@@ -10,16 +10,12 @@ from dpytools.logging.logger import DpLogger
 from dpytools.s3.basic import _get_s3_client, upload_local_file_to_s3
 from dpytools.stores.directory.local import LocalDirectoryStore
 
-from dpypelines.pipeline.errors import (
-    DatasetAPIRequestCreationException,
-    DistributionsException,
-    ValidationException,
+from dpypelines.pipeline.dataset_api import (
+    check_dataset_type_is_static,
+    get_post_request_values_from_metadata,
 )
-from dpypelines.pipeline.messages.email_templates import (
-    submission_processed_email,
-    successful_file_upload_email,
-    successful_metadata_submission,
-)
+from dpypelines.pipeline.errors import ValidationException
+from dpypelines.pipeline.messages.email_templates import submission_processed_email
 from dpypelines.pipeline.messages.notification import (
     PipelineNotifier,
     notifier_from_env_var_webhook,
@@ -165,33 +161,34 @@ def upload_to_s3_processing_folder(
     return s3_processing_folder
 
 
-def copy_s3_processing_folder_to_processed_folder(
+def copy_s3_processing_folder_to_destination_folder(
     s3_object_name: str,
     decompressed_file_dir: Path,
     s3_processing_folder: str,
+    destination: str,
 ) -> str:
     """
-    Copy all files in S3 "processing" folder to S3 "processed" folder.
+    Copy all files in S3 "processing" folder to S3 destination folder.
     """
     bucket_name, object_key = s3_object_name.split("/", maxsplit=1)
-    s3_processed_folder = f"processed/{datetime.now().strftime('%y-%m-%dT%H-%M')}-{decompressed_file_dir.parts[-1]}"
+    s3_destination_folder = f"{destination}/{datetime.now().strftime('%y-%m-%dT%H-%M')}-{decompressed_file_dir.parts[-1]}"
     s3_client = _get_s3_client(profile_name=os.environ.get("AWS_PROFILE"))
 
-    # Copy unzipped files from S3 "processing" folder to "processed" folder
+    # Copy unzipped files from S3 "processing" folder to destination folder
     for file_path in decompressed_file_dir.rglob("*"):
         s3_client.copy_object(
             Bucket=bucket_name,
-            Key=f"{s3_processed_folder}/{file_path.name}",
+            Key=f"{s3_destination_folder}/{file_path.name}",
             CopySource={
                 "Bucket": bucket_name,
                 "Key": f"{s3_processing_folder}/{file_path.name}",
             },
         )
 
-    # Copy original zip file from S3 "processing" folder to "processed" folder
+    # Copy original zip file from S3 "processing" folder to destination folder
     s3_client.copy_object(
         Bucket=bucket_name,
-        Key=f"{s3_processed_folder}/{object_key}",
+        Key=f"{s3_destination_folder}/{object_key}",
         CopySource={
             "Bucket": bucket_name,
             "Key": f"{s3_processing_folder}/{object_key}",
@@ -199,10 +196,10 @@ def copy_s3_processing_folder_to_processed_folder(
     )
     logger.info(
         "Decompressed files and original zip submission copied to S3 'processed' folder",
-        data={"s3_processed_folder": s3_processed_folder},
+        data={"s3_processed_folder": s3_destination_folder},
     )
 
-    return s3_processed_folder
+    return s3_destination_folder
 
 
 def delete_s3_processing_folder(
@@ -282,143 +279,57 @@ def validate_pipeline(files_dir: Path, pipeline_config: dict) -> dict:
     return validation_results
 
 
-def get_post_request_values_from_metadata(metadata: dict):
+def upload_metadata(metadata) -> bool:
     """
-    Generate the required path values and request body to submit to the Dataset API. This will be submitted as a POST request to the endpoint `/datasets/{dataset_path}/editions/{edition_path}/versions`
+    Upload metadata to the Dataset API.
     """
-    try:
-        dataset_path = metadata.get("dcterms:identifier", None)
-        editions = metadata.get("TBC:edition", None)
-        if editions is not None:
-            edition: dict = editions[0]
-        else:
-            edition = {"dcterms:identifier": None}
-        edition_path = edition.get("dcterms:identifier", None)
-        dcat_distributions = edition.get("dcat:distribution", None)
-        if dcat_distributions is not None:
-            distributions = get_distribution_details_for_request(dcat_distributions)
-        else:
-            distributions = None
-
-        request_body = {
-            # Required properties (from swagger.yaml)
-            "distributions": distributions,
-            "release_date": "The release date of this version of the dataset",
-            # Tier 0 metadata standards - required with output
-            "title": metadata.get("dcterms:title", None),
-            "description": metadata.get("dcterms:description", None),
-            "next_release": metadata.get("TBC:nextRelease", None),
-            # Tier 0 metadata standards - added during publishing
-            "type": "static",
-            "state": "associated",
-            "themes": metadata.get("dcat:theme", None),
-            # Additional properties (from swagger.yaml)
-            "alerts": edition.get("TBC:alerts", None),
-            "quality_designation": edition.get("TBC:quality_designation", None),
-            "usage_notes": edition.get("TBC:usage_notes", None),
-            # TODO `links:spatial` and `links:job` fields to be removed from data model - hardcode for now to allow request to succeed
-            "links": {
-                "spatial": {"href": "string"},
-                "job": {"href": "string", "id": "string"},
-            },
-            # Not included here ($ref: '#/definitions/Version')
-            # collection_id (auto generated?)
-            # dimensions $ref: '#/definitions/Dimension'
-            # edition (readOnly - auto generated?)
-            # dataset_id (auto generated?)
-            # is_based_on (census only)
-            # last_updated (readOnly - auto generated?)
-            # latest_changes $ref: '#/definitions/LatestChange'
-            # links (auto generated?)
-            # lowest_geography (census only)
-            # temporal $ref: '#/definitions/Temporal'
-            # version (readOnly - auto generated?)
-        }
-        return dataset_path, edition_path, request_body
-    except Exception as err:
-        raise DatasetAPIRequestCreationException(
-            "Error getting POST request values from metadata", metadata=metadata
-        ) from err
-
-
-def get_distribution_details_for_request(dcat_distributions: list) -> list:
-    """
-    Get the information to populate the `distributions` property in the POST request to the Dataset API.
-    """
-    try:
-        distributions = [
-            {
-                "title": distribution["dcterms:title"],
-                "download_url": "The URL to the generated file",
-                # TODO Calculate byte_size during processing
-                "byte_size": "The size of the file in bytes",
-                "format": distribution["TBC:distributionFormat"],
-                "media_type": distribution["dcat:mediaType"],
-            }
-            for distribution in dcat_distributions
-        ]
-        logger.info(
-            "Distributions information retrieved",
-            data={"distributions": distributions},
-        )
-        return distributions
-    except Exception as err:
-        raise DistributionsException(
-            "Error getting details of distributions for Dataset API request",
-            distributions=dcat_distributions,
-        ) from err
-
-
-def upload_metadata(local_store, email_client, submitter_email):
-    """Upload metadata and send notifications."""
     dataset_api_url = os.environ.get("DATASET_API_URL")
     if not dataset_api_url:
-        err_msg = (
-            f"Required environment variable(s) not set: "
-            f"DATASET_API_URL: {dataset_api_url}."
-        )
-        raise EnvironmentError(err_msg)
+        msg = "Required environment variable not set: DATASET_API_URL"
+        raise EnvironmentError(msg)
 
-    metadata = local_store.get_lone_matching_json_as_dict("^metadata.json$")
-    if not metadata:
-        err_msg = "metadata.json not found in the local store."
-        raise FileNotFoundError(err_msg)
-
+    # Generate POST request body from metadata
     dataset_path, edition_path, request_body = get_post_request_values_from_metadata(
         metadata
     )
     dataset_api_client = DatasetAPIClient(dataset_api_url, dataset_path, edition_path)
-    dataset_api_get_path_response = dataset_api_client.get_path()
-    logger.info(
-        "Dataset API endpoint exists",
-        data={"dataset_api_endpoint": dataset_api_client.full_url},
-    )
 
-    if dataset_api_get_path_response.status_code == 200:
-        dataset_api_client.post_json(request_body)
-        logger.info(
-            "Metadata submitted to Dataset API endpoint",
-            data={"dataset_api_endpoint": dataset_api_client.full_url},
-        )
-        email_content = successful_metadata_submission(dataset_path)
-        email_client.send(submitter_email, email_content.subject, email_content.message)
-    else:
-        dataset_api_get_path_response.raise_for_status()
+    # Upload metadata only if the dataset type is "static"
+    if check_dataset_type_is_static(dataset_api_client):
+        # Verify that the relevant Dataset API endpoint exists
+        get_versions_path_response = dataset_api_client.get_path()
+
+        # If the endpoint exists, send POST request
+        if get_versions_path_response.status_code != 200:
+            get_versions_path_response.raise_for_status()
+        else:
+            logger.info(
+                "Dataset API endpoint exists",
+                data={"dataset_api_endpoint": dataset_api_client.full_url},
+            )
+
+            post_json_response = dataset_api_client.post_json(request_body)
+
+            if post_json_response.status_code == 201:
+                logger.info(
+                    "Metadata submitted to Dataset API endpoint",
+                    data={"dataset_api_endpoint": dataset_api_client.full_url},
+                )
+                return True
+    return False
 
 
-def upload_files(validation_results, email_client, submitter_email):
-    """Upload files and send notifications."""
+def upload_files(files_to_upload):
+    """
+    Upload data files to the Upload Service.
+    """
     upload_url = os.environ.get("UPLOAD_SERVICE_URL")
-    dataset_api_url = os.environ.get("DATASET_API_URL")
-    if not upload_url or not dataset_api_url:
-        err_msg = (
-            f"Required environment variable(s) not set: "
-            f"UPLOAD_SERVICE_URL: {upload_url}, DATASET_API_URL: {dataset_api_url}."
-        )
+    if not upload_url:
+        err_msg = "Required environment variable not set: UPLOAD_SERVICE_URL."
         raise EnvironmentError(err_msg)
 
     upload_client = UploadServiceClient(upload_url)
-    for required_file_path in validation_results["config_files"]:
+    for required_file_path in files_to_upload:
         mimetype = get_mimetype(Path(required_file_path).suffix)
         if not mimetype:
             err_msg = f"Uploading file type {Path(required_file_path).suffix} not supported for file: {required_file_path}."
@@ -428,12 +339,6 @@ def upload_files(validation_results, email_client, submitter_email):
         logger.info(
             "File uploaded",
             data={"file_path": required_file_path, "upload_url": upload_url},
-        )
-        email_content = successful_file_upload_email(Path(required_file_path).name)
-        email_client.send(submitter_email, email_content.subject, email_content.message)
-        logger.info(
-            "Upload notification email sent",
-            data={"submitter_email": submitter_email, "file": required_file_path},
         )
 
 

--- a/dpypelines/s3_folder_received.py
+++ b/dpypelines/s3_folder_received.py
@@ -5,7 +5,7 @@ from dpytools.utilities.utilities import str_to_bool
 
 from dpypelines.pipeline.messages.error_handler_module import error_handler
 from dpypelines.pipeline.utils import (
-    copy_s3_processing_folder_to_processed_folder,
+    copy_s3_processing_folder_to_destination_folder,
     delete_s3_processing_folder,
     process_zip_file,
     send_submission_confirmation,
@@ -49,30 +49,48 @@ def start(s3_object_name: str, *args, **kwargs):
         )
         validation_results = validate_pipeline(files_dir, pipeline_config)
 
-        # Upload files & metadata to external APIs.
+        # Upload metadata to Dataset API.
         if not str_to_bool(os.environ.get("SKIP_DATA_UPLOAD", "False")):
-            upload_files(
-                validation_results, email_client, manifest_dict["fileAuthorEmail"]
+            metadata_submitted = upload_metadata(
+                validation_results["metadata"],
             )
-            upload_metadata(local_store, email_client, manifest_dict["fileAuthorEmail"])
+            if metadata_submitted:
+                # If metadata successfully submitted, upload data files to the Upload Service
+                upload_files(validation_results["config_files"])
 
-        send_submission_confirmation(email_client, manifest_dict["fileAuthorEmail"])
+                # Copy all files in S3 "processing" folder to S3 "processed" folder
+                copy_s3_processing_folder_to_destination_folder(
+                    s3_object_name,
+                    decompressed_file_dir,
+                    s3_processing_folder,
+                    "processed",
+                )
 
-        # Copy all files in S3 "processing" folder to S3 "processed" folder
-        copy_s3_processing_folder_to_processed_folder(
-            s3_object_name,
-            decompressed_file_dir,
-            s3_processing_folder,
-        )
+                send_submission_confirmation(
+                    email_client, manifest_dict["fileAuthorEmail"]
+                )
 
-        # Delete files from S3 "processing" folder to indicate successful submission
-        delete_s3_processing_folder(
-            s3_object_name, decompressed_file_dir, s3_processing_folder
-        )
+                notifier.success()
+                logger.info("ETL process completed successfully")
 
-        notifier.success()
-        logger.info("ETL process completed successfully")
-        return True
+                # Delete files from S3 "processing" folder
+                delete_s3_processing_folder(
+                    s3_object_name, decompressed_file_dir, s3_processing_folder
+                )
+                return True
+            else:
+                # Copy all files in S3 "processing" folder to S3 "dataset-type-not-static" folder
+                copy_s3_processing_folder_to_destination_folder(
+                    s3_object_name,
+                    decompressed_file_dir,
+                    s3_processing_folder,
+                    "dataset-type-not-static",
+                )
+                # Delete files from S3 "processing" folder
+                delete_s3_processing_folder(
+                    s3_object_name, decompressed_file_dir, s3_processing_folder
+                )
+                return False
 
     except Exception as err:
         logger.error("ETL process failed", err)

--- a/tests/fixtures/test-cases/test_metadata.json
+++ b/tests/fixtures/test-cases/test_metadata.json
@@ -18,45 +18,53 @@
     ],
     "dqv:hasQualityAnnotation": [
         {
-            "dqv:QualityCertificate": "qmi.href.string_required"
+            "dqv:QualityCertificate": "QMI URL"
         }
     ],
     "dcat:contactPoint": [
         {
-            "vcard:fn": "contact.name.string_required",
-            "vcard:hasEmail": "contact.email.string_required",
-            "vcard:hasTelephone": "contact.telephone.string"
+            "vcard:fn": "Contact name",
+            "vcard:hasEmail": "Contact email",
+            "vcard:hasTelephone": "Contact telephone"
         }
     ],
     "dcterms:publisher": [
         {
-            "TBC:type": "publisher.type.string_required",
-            "foaf:name": "publisher.name.string_required",
-            "foaf:homepage": "publisher.href.string_required"
+            "TBC:type": "Publisher type",
+            "foaf:name": "Publisher name",
+            "foaf:homepage": "Publisher link"
         }
     ],
     "TBC:edition": [
         {
             "@type": "dcat:Dataset",
             "dcterms:identifier": "time-series",
+            "dcterms:title": "Edition title",
             "TBC:quality_designation": "QualityDesignationEnum",
             "TBC:usage_notes": [
                 {
-                    "TBC:title": "usage_notes.title.string",
-                    "TBC:note": "usage_notes.note.string"
+                    "TBC:title": "Usge note title",
+                    "TBC:note": "Usage note description"
                 }
             ],
             "TBC:alerts": [
                 {
                     "TBC:type": "AlertTypeEnum",
-                    "adms:versionNotes": "alerts.description.string_required"
+                    "adms:versionNotes": "Alert description"
                 }
             ],
             "dcat:distribution": [
                 {
-                    "dcterms:title": "distribution.title.string_required",
-                    "dcat:mediaType": "MediaTypeEnum",
-                    "TBC:distributionFormat": "DistributionFormatEnum"
+                    "dcterms:title": "CSV distribution title",
+                    "download_url": "https://download.ons.gov.uk/download.csv",
+                    "dcat:mediaType": "text/csv",
+                    "TBC:distributionFormat": "csv"
+                },
+                {
+                    "dcterms:title": "XLS distribution title",
+                    "download_url": "https://download.ons.gov.uk/download.xls",
+                    "dcat:mediaType": "application/vnd.ms-excel",
+                    "TBC:distributionFormat": "xls"
                 }
             ]
         }

--- a/tests/pipelines/pipeline/test_dataset_api.py
+++ b/tests/pipelines/pipeline/test_dataset_api.py
@@ -1,0 +1,134 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dpypelines.pipeline.dataset_api import (
+    check_dataset_type_is_static,
+    get_post_request_values_from_metadata,
+)
+from dpypelines.pipeline.errors import (
+    DatasetAPIRequestCreationException,
+    DatasetTypeException,
+)
+
+
+def test_get_post_request_values_from_valid_metadata():
+    """
+    Tests that the correct dataset_path, edition_path and request_body are returned from a valid metadata.json file
+    """
+    with open("tests/fixtures/test-cases/test_metadata.json", "r") as f:
+        metadata = json.load(f)
+    dataset_path, edition_path, request_body = get_post_request_values_from_metadata(
+        metadata
+    )
+    assert dataset_path == "trade"
+    assert edition_path == "time-series"
+    assert request_body["title"] == "Dataset title"
+    assert ["title", "download_url", "byte_size", "format", "media_type"] == list(
+        request_body["distributions"][0].keys()
+    )
+
+
+def test_get_post_request_values_from_invalid_metadata():
+    """
+    Tests that an error is raised if attempting to get request parameters with an invalid metadata.json file.
+    """
+    with open("tests/fixtures/test-cases/test_metadata_invalid.json", "r") as f:
+        metadata = json.load(f)
+
+    with pytest.raises(DatasetAPIRequestCreationException) as e:
+        get_post_request_values_from_metadata(metadata)
+
+    assert "DatasetAPIRequestCreationException" in str(e)
+
+
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
+def test_check_dataset_type_is_static(mock_dataset_api_client):
+    mock_dataset_api_client = MagicMock()
+    mock_dataset_api_client.dataset_api_url = "http://dataset-api.url"
+    mock_dataset_api_client.dataset_path = "dataset_id"
+    mock_dataset_api_client.get.return_value.text = '{"current": {"type": "static"}}'
+    mock_dataset_api_client.get.return_value.status_code = 200
+
+    dataset_is_static = check_dataset_type_is_static(mock_dataset_api_client)
+
+    assert dataset_is_static
+    mock_dataset_api_client.get.assert_called_once_with(
+        "http://dataset-api.url/dataset_id",
+        headers=mock_dataset_api_client.token_auth.get_auth_header.return_value,
+    )
+
+
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
+def test_check_dataset_type_is_not_static(mock_dataset_api_client):
+    mock_dataset_api_client = MagicMock()
+    mock_dataset_api_client.dataset_api_url = "http://dataset-api.url"
+    mock_dataset_api_client.dataset_path = "dataset_id"
+    mock_dataset_api_client.get.return_value.text = (
+        '{"current": {"type": "not-static"}}'
+    )
+    mock_dataset_api_client.get.return_value.status_code = 200
+
+    dataset_is_static = check_dataset_type_is_static(mock_dataset_api_client)
+
+    assert not dataset_is_static
+    mock_dataset_api_client.get.assert_called_once_with(
+        "http://dataset-api.url/dataset_id",
+        headers=mock_dataset_api_client.token_auth.get_auth_header.return_value,
+    )
+
+
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
+def test_check_dataset_type_is_missing(mock_dataset_api_client):
+    mock_dataset_api_client = MagicMock()
+    mock_dataset_api_client.dataset_api_url = "http://dataset-api.url"
+    mock_dataset_api_client.dataset_path = "dataset_id"
+    mock_dataset_api_client.get.return_value.text = '{"current": {"key": "value"}}'
+    mock_dataset_api_client.get.return_value.status_code = 200
+
+    with pytest.raises(DatasetTypeException) as e:
+        check_dataset_type_is_static(mock_dataset_api_client)
+
+    assert "DatasetTypeException" in str(e)
+    mock_dataset_api_client.get.assert_called_once_with(
+        "http://dataset-api.url/dataset_id",
+        headers=mock_dataset_api_client.token_auth.get_auth_header.return_value,
+    )
+
+
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
+def test_check_dataset_type_current_missing(mock_dataset_api_client):
+    mock_dataset_api_client = MagicMock()
+    mock_dataset_api_client.dataset_api_url = "http://dataset-api.url"
+    mock_dataset_api_client.dataset_path = "dataset_id"
+    mock_dataset_api_client.get.return_value.text = '{"key": {"key": "value"}}'
+    mock_dataset_api_client.get.return_value.status_code = 200
+
+    with pytest.raises(KeyError) as e:
+        check_dataset_type_is_static(mock_dataset_api_client)
+
+    assert "'current' not found in dataset_result keys" in str(e)
+    mock_dataset_api_client.get.assert_called_once_with(
+        "http://dataset-api.url/dataset_id",
+        headers=mock_dataset_api_client.token_auth.get_auth_header.return_value,
+    )
+
+
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
+def test_check_dataset_type_404(mock_dataset_api_client):
+    mock_dataset_api_client = MagicMock(name="dataset_api_client")
+    mock_dataset_api_client.dataset_api_url = "http://dataset-api.url"
+    mock_dataset_api_client.dataset_path = "dataset_id"
+    mock_dataset_api_client.get.return_value.text = '{"key": {"key": "value"}}'
+    mock_dataset_api_client.get.return_value.status_code = 404
+
+    with pytest.raises(Exception) as e:
+        check_dataset_type_is_static(mock_dataset_api_client)
+
+    assert "DatasetNotFoundException" in str(e)
+    mock_dataset_api_client.get.assert_called_once_with(
+        "http://dataset-api.url/dataset_id",
+        headers=mock_dataset_api_client.token_auth.get_auth_header.return_value,
+    )
+    mock_dataset_api_client.get.return_value.raise_for_status.assert_called_once()

--- a/tests/pipelines/pipeline/test_pipeline_utils.py
+++ b/tests/pipelines/pipeline/test_pipeline_utils.py
@@ -8,17 +8,16 @@ from zipfile import ZipFile
 
 import pytest
 
-from dpypelines.pipeline.errors import DatasetAPIRequestCreationException
 from dpypelines.pipeline.utils import (
-    copy_s3_processing_folder_to_processed_folder,
+    copy_s3_processing_folder_to_destination_folder,
     decompress_zip_file,
     delete_s3_processing_folder,
     download_zip_file,
-    get_post_request_values_from_metadata,
     process_zip_file,
     send_submission_confirmation,
     setup_clients,
     upload_files,
+    upload_metadata,
     upload_to_s3_processing_folder,
     validate_pipeline,
 )
@@ -93,8 +92,6 @@ def test_validate_pipeline(mock_validate_pipeline_files):
 def test_upload_files(mock_get_mimetype, mock_UploadServiceClient):
     """Test that `upload_files()` uploads the files and sends the email."""
     mock_validation_results = {"config_files": ["file1", "file2"]}
-    mock_email_client = MagicMock()
-    mock_submitter_email = "test@example.com"
     mock_upload_client = MagicMock()
 
     mock_get_mimetype.return_value = "text/csv"
@@ -104,15 +101,13 @@ def test_upload_files(mock_get_mimetype, mock_UploadServiceClient):
         os.environ,
         {
             "UPLOAD_SERVICE_URL": "http://upload.url",
-            "DATASET_API_URL": "http://dataset.api.url",
         },
     ):
-        upload_files(mock_validation_results, mock_email_client, mock_submitter_email)
+        upload_files(mock_validation_results)
 
     mock_UploadServiceClient.assert_called_once_with("http://upload.url")
     mock_get_mimetype.assert_called()
     mock_upload_client.upload_new.assert_called()
-    mock_email_client.send.assert_called()
 
 
 @patch("dpypelines.pipeline.utils.submission_processed_email")
@@ -397,10 +392,11 @@ def test_copy_s3_processing_folder_to_processed_folder(
     now = datetime.now()
     mock_timestamp.now.return_value = now
 
-    s3_processed_folder = copy_s3_processing_folder_to_processed_folder(
+    s3_processed_folder = copy_s3_processing_folder_to_destination_folder(
         s3_object_name="bucket/key/file.zip",
         decompressed_file_dir=mock_path,
         s3_processing_folder=f"processing/{now.strftime('%y-%m-%dT%H-%M')}-file",
+        destination="processed",
     )
 
     assert s3_processed_folder == f"processed/{now.strftime('%y-%m-%dT%H-%M')}-file"
@@ -564,31 +560,110 @@ def test_process_zip_file_errors_when_no_files(
     )
 
 
-def test_get_post_request_values_from_valid_metadata():
-    """
-    Tests that the correct dataset_path, edition_path and request_body are returned from a valid metadata.json file
-    """
-    with open("tests/fixtures/test-cases/test_metadata.json", "r") as f:
-        metadata = json.load(f)
-    dataset_path, edition_path, request_body = get_post_request_values_from_metadata(
-        metadata
-    )
-    assert dataset_path == "trade"
-    assert edition_path == "time-series"
-    assert request_body["title"] == "Dataset title"
-    assert ["title", "download_url", "byte_size", "format", "media_type"] == list(
-        request_body["distributions"][0].keys()
-    )
+@patch("dpypelines.pipeline.utils.check_dataset_type_is_static")
+@patch("dpypelines.pipeline.utils.get_post_request_values_from_metadata")
+@patch("dpypelines.pipeline.utils.DatasetAPIClient")
+def test_upload_metadata_succeeds(
+    mock_DatasetAPIClient, mock_request_values, mock_dataset_type
+):
+    mock_dataset_api_client = MagicMock()
+    mock_DatasetAPIClient.return_value = mock_dataset_api_client
+    mock_dataset_api_client.get_path.return_value.status_code = 200
+    mock_dataset_api_client.post_json.return_value.status_code = 201
 
-
-def test_get_post_request_values_from_invalid_metadata():
-    """
-    Tests that an error is raised if attempting to get request parameters with an invalid metadata.json file.
-    """
-    with open("tests/fixtures/test-cases/test_metadata_invalid.json", "r") as f:
+    mock_request_values.return_value = (
+        "dataset_path",
+        "edition_path",
+        {"key": "value"},
+    )
+    mock_dataset_type.return_value = True
+    with open("tests/fixtures/test-cases/test_metadata.json") as f:
         metadata = json.load(f)
 
-    with pytest.raises(DatasetAPIRequestCreationException) as e:
-        get_post_request_values_from_metadata(metadata)
+    with patch.dict(
+        os.environ,
+        {
+            "DATASET_API_URL": "http://dataset-api.url",
+        },
+    ):
+        metadata_uploaded = upload_metadata(metadata)
 
-    assert "DatasetAPIRequestCreationException" in str(e)
+    mock_DatasetAPIClient.assert_called_once_with(
+        "http://dataset-api.url", "dataset_path", "edition_path"
+    )
+    mock_dataset_api_client.get_path.assert_called_once()
+
+    mock_request_values.assert_called_once_with(metadata)
+    mock_dataset_type.assert_called_once_with(mock_dataset_api_client)
+    assert metadata_uploaded
+
+
+@patch("dpypelines.pipeline.utils.check_dataset_type_is_static")
+@patch("dpypelines.pipeline.utils.get_post_request_values_from_metadata")
+@patch("dpypelines.pipeline.utils.DatasetAPIClient")
+def test_upload_metadata_fails_not_static(
+    mock_DatasetAPIClient, mock_request_values, mock_dataset_type
+):
+    mock_dataset_api_client = MagicMock()
+    mock_DatasetAPIClient.return_value = mock_dataset_api_client
+    mock_dataset_api_client.get_path.return_value.status_code = 200
+
+    mock_request_values.return_value = (
+        "dataset_path",
+        "edition_path",
+        {"key": "value"},
+    )
+    mock_dataset_type.return_value = False
+    with open("tests/fixtures/test-cases/test_metadata.json") as f:
+        metadata = json.load(f)
+
+    with patch.dict(
+        os.environ,
+        {
+            "DATASET_API_URL": "http://dataset-api.url",
+        },
+    ):
+        metadata_uploaded = upload_metadata(metadata)
+
+    mock_DatasetAPIClient.assert_called_once_with(
+        "http://dataset-api.url", "dataset_path", "edition_path"
+    )
+
+    mock_request_values.assert_called_once_with(metadata)
+    mock_dataset_type.assert_called_once_with(mock_dataset_api_client)
+    assert not metadata_uploaded
+
+
+@patch("dpypelines.pipeline.utils.check_dataset_type_is_static")
+@patch("dpypelines.pipeline.utils.get_post_request_values_from_metadata")
+@patch("dpypelines.pipeline.utils.DatasetAPIClient")
+def test_upload_metadata_fails_get_path_404(
+    mock_DatasetAPIClient, mock_request_values, mock_dataset_type
+):
+    mock_dataset_api_client = MagicMock()
+    mock_DatasetAPIClient.return_value = mock_dataset_api_client
+    mock_dataset_api_client.get_path.return_value.status_code = 404
+
+    mock_request_values.return_value = (
+        "dataset_path",
+        "edition_path",
+        {"key": "value"},
+    )
+    mock_dataset_type.return_value = True
+    with open("tests/fixtures/test-cases/test_metadata.json") as f:
+        metadata = json.load(f)
+
+    with patch.dict(
+        os.environ,
+        {
+            "DATASET_API_URL": "http://dataset-api.url",
+        },
+    ):
+        upload_metadata(metadata)
+
+    mock_DatasetAPIClient.assert_called_once_with(
+        "http://dataset-api.url", "dataset_path", "edition_path"
+    )
+    mock_dataset_api_client.get_path.return_value.raise_for_status.assert_called_once()
+    mock_request_values.assert_called_once_with(metadata)
+    mock_dataset_type.assert_called_once_with(mock_dataset_api_client)

--- a/tests/pipelines/pipeline/test_s3_folder_received.py
+++ b/tests/pipelines/pipeline/test_s3_folder_received.py
@@ -1,4 +1,4 @@
-import re
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -7,93 +7,190 @@ import pytest
 from dpypelines.s3_folder_received import start
 
 
-@patch(
-    "dpypelines.s3_folder_received.process_zip_file",
-    side_effect=FileNotFoundError(
-        "[Errno 2] No such file or directory: 'dummy_s3_object_name'"
-    ),
-)
-@patch("dpypelines.pipeline.utils.Path.is_dir", return_value=True)
-@patch("dpypelines.pipeline.utils.Path.exists", return_value=True)
-@patch("dpypelines.s3_folder_received.setup_clients")
-@patch("dpypelines.s3_folder_received.retrieve_config_and_files")
-@patch("dpypelines.s3_folder_received.validate_pipeline")
+@patch("dpypelines.s3_folder_received.delete_s3_processing_folder")
+@patch("dpypelines.s3_folder_received.copy_s3_processing_folder_to_destination_folder")
+@patch("dpypelines.s3_folder_received.upload_metadata")
 @patch("dpypelines.s3_folder_received.upload_files")
-@patch("dpypelines.s3_folder_received.send_submission_confirmation")
-def test_start_valid_data(
-    mock_send_submission_confirmation,
-    mock_upload_files,
-    mock_validate_pipeline,
-    mock_retrieve_config_and_files,
+@patch("dpypelines.s3_folder_received.validate_pipeline")
+@patch("dpypelines.s3_folder_received.retrieve_config_and_files")
+@patch("dpypelines.s3_folder_received.process_zip_file")
+@patch("dpypelines.s3_folder_received.setup_clients")
+def test_start_succeeds(
     mock_setup_clients,
-    mock_path_exists,
-    mock_path_isdir,
     mock_process_zip_file,
+    mock_config_and_files,
+    mock_validation,
+    mock_upload_files,
+    mock_upload_metadata,
+    mock_copy_s3_processing,
+    mock_delete_s3_processing,
 ):
-    """
-    Test that `start()` raises an Exception with the expected message when processing the zip file fails.
-    """
-    mock_setup_clients.return_value = (MagicMock(), MagicMock())
-    mock_retrieve_config_and_files.return_value = (
+    mock_notifier, mock_email_client = (
+        MagicMock(name="notifier"),
+        MagicMock(name="email_client"),
+    )
+    mock_setup_clients.return_value = (mock_notifier, mock_email_client)
+    mock_local_store = MagicMock(name="local_store")
+    mock_process_zip_file.return_value = (
+        mock_local_store,
+        Path("files_dir"),
+        "processing/timestamp-files",
+    )
+    mock_config_and_files.return_value = (
         {"fileAuthorEmail": "test@example.com"},
         {"config": "value"},
         "files_dir",
     )
-    mock_validate_pipeline.side_effect = FileNotFoundError(
-        "[Errno 2] No such file or directory: 'dummy_s3_object_name'"
-    )
+    mock_validation.return_value = {
+        "manifest": {"fileAuthorEmail": "test@example.com"},
+        "metadata": {"key": "value"},
+        "input_files": ["data.csv", "metadata.json"],
+        "config_files": ["data.csv", "metadata.json"],
+        "supplementary_files": ["data.xls"],
+    }
+    mock_upload_metadata.return_value = True
+    mock_copy_s3_processing.return_value = "processed/timestamp-files"
 
-    with pytest.raises(
-        Exception,
-        match=re.escape("[Errno 2] No such file or directory: 'dummy_s3_object_name'"),
+    with patch.dict(
+        os.environ,
+        {
+            "DATASET_API_URL": "http://dataset-api.url",
+            "UPLOAD_SERVICE_URL": "http://upload-service.url",
+        },
     ):
         start("dummy_s3_object_name")
 
+    mock_setup_clients.assert_called_once()
+    mock_process_zip_file.assert_called_once_with("dummy_s3_object_name")
+    mock_config_and_files.assert_called_once_with(mock_local_store)
+    mock_validation.assert_called_once_with("files_dir", {"config": "value"})
+    mock_upload_files.assert_called_once_with(["data.csv", "metadata.json"])
+    mock_upload_metadata.assert_called_once_with({"key": "value"})
+    mock_copy_s3_processing.assert_called_once_with(
+        "dummy_s3_object_name",
+        Path("files_dir"),
+        "processing/timestamp-files",
+        "processed",
+    )
+    mock_notifier.success.assert_called_once()
+    mock_delete_s3_processing.assert_called_once_with(
+        "dummy_s3_object_name", Path("files_dir"), "processing/timestamp-files"
+    )
 
-@patch("dpypelines.s3_folder_received.process_zip_file")
-@patch("dpypelines.pipeline.utils.Path.is_dir", return_value=True)
-@patch("dpypelines.pipeline.utils.Path.exists", return_value=True)
-@patch("dpypelines.s3_folder_received.setup_clients")
-@patch("dpypelines.s3_folder_received.retrieve_config_and_files")
+
+@patch("dpypelines.s3_folder_received.delete_s3_processing_folder")
+@patch("dpypelines.s3_folder_received.copy_s3_processing_folder_to_destination_folder")
+@patch("dpypelines.s3_folder_received.upload_metadata")
 @patch("dpypelines.s3_folder_received.validate_pipeline")
-@patch("dpypelines.s3_folder_received.upload_files")
-@patch("dpypelines.s3_folder_received.send_submission_confirmation")
-@patch("dpypelines.s3_folder_received.error_handler")
-def test_start_missing_files(
-    mock_error_handler,
-    mock_send_submission_confirmation,
-    mock_upload_files,
-    mock_validate_pipeline,
-    mock_retrieve_config_and_files,
+@patch("dpypelines.s3_folder_received.retrieve_config_and_files")
+@patch("dpypelines.s3_folder_received.process_zip_file")
+@patch("dpypelines.s3_folder_received.setup_clients")
+def test_start_fails_dataset_not_static(
     mock_setup_clients,
-    mock_path_exists,
-    mock_path_isdir,
     mock_process_zip_file,
+    mock_config_and_files,
+    mock_validation,
+    mock_upload_metadata,
+    mock_copy_s3_processing,
+    mock_delete_s3_processing,
+):
+    mock_notifier, mock_email_client = (
+        MagicMock(name="notifier"),
+        MagicMock(name="email_client"),
+    )
+    mock_setup_clients.return_value = (mock_notifier, mock_email_client)
+    mock_local_store = MagicMock(name="local_store")
+    mock_process_zip_file.return_value = (
+        mock_local_store,
+        Path("files_dir"),
+        "processing/timestamp-files",
+    )
+    mock_config_and_files.return_value = (
+        {"fileAuthorEmail": "test@example.com"},
+        {"config": "value"},
+        "files_dir",
+    )
+    mock_validation.return_value = {
+        "manifest": {"fileAuthorEmail": "test@example.com"},
+        "metadata": {"key": "value"},
+        "input_files": ["data.csv", "metadata.json"],
+        "config_files": ["data.csv", "metadata.json"],
+        "supplementary_files": ["data.xls"],
+    }
+    mock_upload_metadata.return_value = False
+    mock_copy_s3_processing.return_value = "processed/timestamp-files"
+
+    with patch.dict(
+        os.environ,
+        {
+            "DATASET_API_URL": "http://dataset-api.url",
+            "UPLOAD_SERVICE_URL": "http://upload-service.url",
+        },
+    ):
+        start("dummy_s3_object_name")
+
+    mock_setup_clients.assert_called_once()
+    mock_process_zip_file.assert_called_once_with("dummy_s3_object_name")
+    mock_config_and_files.assert_called_once_with(mock_local_store)
+    mock_validation.assert_called_once_with("files_dir", {"config": "value"})
+    mock_upload_metadata.assert_called_once_with({"key": "value"})
+    mock_copy_s3_processing.assert_called_once_with(
+        "dummy_s3_object_name",
+        Path("files_dir"),
+        "processing/timestamp-files",
+        "dataset-type-not-static",
+    )
+    mock_delete_s3_processing.assert_called_once_with(
+        "dummy_s3_object_name", Path("files_dir"), "processing/timestamp-files"
+    )
+
+
+@patch("dpypelines.s3_folder_received.error_handler")
+@patch("dpypelines.s3_folder_received.delete_s3_processing_folder")
+@patch("dpypelines.s3_folder_received.validate_pipeline")
+@patch("dpypelines.s3_folder_received.retrieve_config_and_files")
+@patch("dpypelines.s3_folder_received.process_zip_file")
+@patch("dpypelines.s3_folder_received.setup_clients")
+def test_start_fails_invalid_manifest(
+    mock_setup_clients,
+    mock_process_zip_file,
+    mock_config_and_files,
+    mock_validate_pipeline,
+    mock_delete_s3_processing,
+    mock_error_handler,
 ):
     """
     Test that `start()` raises an exception when the manifest is invalid.
     """
-    mock_notifier = MagicMock()
-    mock_email_client = MagicMock()
+    mock_notifier, mock_email_client = (
+        MagicMock(name="notifier"),
+        MagicMock(name="email_client"),
+    )
     mock_setup_clients.return_value = (mock_notifier, mock_email_client)
-    mock_local_store = MagicMock()
-    mock_decompressed_file_dir = Path("decompressed_files_dir")
-    mock_s3_processing_folder = "processing"
+    mock_local_store = MagicMock(name="local_store")
     mock_process_zip_file.return_value = (
         mock_local_store,
-        mock_decompressed_file_dir,
-        mock_s3_processing_folder,
+        Path("decompressed_files_dir"),
+        "processing/timestamp-file",
     )
-    mock_manifest_dict = {"fileAuthorEmail": "test@example.com"}
-    mock_pipeline_config = {"config": "value"}
-    mock_files_dir = "files_dir"
-    mock_local_store.get_current_source_pathlike.return_value = Path(mock_files_dir)
-    mock_retrieve_config_and_files.return_value = (
-        mock_manifest_dict,
-        mock_pipeline_config,
-        mock_files_dir,
+    mock_config_and_files.return_value = (
+        {"fileAuthorEmail": "test@example.com"},
+        {"config": "value"},
+        Path("files_dir"),
     )
+    mock_validate_pipeline.side_effect = ValueError(
+        "Failed to retrieve and validate manifest"
+    )
+    mock_delete_s3_processing = MagicMock("delete_s3_processing")
+    mock_delete_s3_processing.return_value = None
+    mock_error_handler = MagicMock("error_handler")
     mock_error_handler.return_value = None
-    mock_validate_pipeline.side_effect = ValueError("Invalid manifest file")
-    with pytest.raises(ValueError, match="Invalid manifest file"):
-        start("dummy_s3_object_name")
+    with pytest.raises(ValueError) as e:
+        start("bucket/folder/file.zip")
+    assert "Failed to retrieve and validate manifest" in str(e)
+    mock_notifier.failure.assert_called_once()
+    mock_process_zip_file.assert_called_once_with("bucket/folder/file.zip")
+    mock_config_and_files.assert_called_once_with(mock_local_store)
+    mock_validate_pipeline.assert_called_once_with(
+        Path("files_dir"), {"config": "value"}
+    )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

`dpypelines/pipeline/dataset_api.py`:

`check_dataset_type_is_static()` sends a GET request to `/datasets/{dataset_path}` to check if the dataset type is static before attempting to submit metadata to the Dataset API.
`get_post_request_values_from_metadata` and `get_distribution_details_for_request` moved to this file from `dpypelines/pipeline/utils.py`. Added a `DatasetTypeException` in `dpypelines/pipeline/errors/dataset_type_exception.py` as well.

`dpypelines/pipeline/utils.py`:

`upload_metadata()` uses result of `check_dataset_type_is_static` to determine whether metadata should be submitted.
`copy_s3_processing_folder_to_processed_folder()` renamed to `copy_s3_processing_folder_to_destination_folder()` and now accepts additional argument specifying destination folder name.

`dpypelines/s3_folder_received.py`:

`start()` updated to move non-static dataset submissions from S3 "processing" folder to "dataset-type-not-static" folder instead of "processed"

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [x] Yes
- [ ] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

Jira ticket: https://jira.ons.gov.uk/browse/DIS-2809

### How to review

Describe the steps required to test the changes.