### PR TITLE
chore: update package versions

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -117,11 +117,8 @@ jobs:
       - name: Install test dependencies
         run: poetry install
 
-      - name: Check black has been ran (make fmt)
-        run: poetry run black dpypelines tests --check
+      - name: Run linting
+        run: poetry run ruff check
 
-      - name: Check isort has been ran (make fmt)
-        run: poetry run isort dpypelines tests --diff --check-only
-
-      - name: Check ruff has been ran (make lint)
-        run: poetry run ruff check dpypelines tests
+      - name: Run formatting
+        run: poetry run ruff format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,32 +7,18 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 
--   repo: https://github.com/psf/black
-    rev: 24.2.0
-    hooks:
-    -   id: black
-        name: black
-        entry: poetry run black
-        language: system
-        types: [python]
-        files: ^(dpypelines|tests)/
-
--   repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-    -   id: isort
-        name: isort
-        entry: poetry run isort
-        language: system
-        types: [python]
-        files: ^(dpypelines|tests)/
-
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.2
     hooks:
     -   id: ruff
-        name: ruff
-        entry: poetry run ruff check
+        name: Ruff format
+        entry: poetry run ruff check --fix
+        language: system
+        types: [python]
+
+    -   id: ruff
+        name: Ruff lint
+        entry: poetry run ruff format
         language: system
         types: [python]
 

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,11 @@ help:
 install: ## Install development dependencies
 	poetry install
 
-fmt: install ## (Format) - runs black and isort against the codebase (auto triggered on pre-commit)
-	poetry run black .
-	poetry run isort ./dpypelines/ ./tests/*
+fmt: install ## (Format) - runs Ruff against the codebase (auto triggered on pre-commit)
+	poetry run ruff format
 
 lint: install ## Run the ruff python linter
-	poetry run ruff check
+	poetry run ruff check --fix
 
 test: install ## Run pytest and check test coverage
 	poetry run pytest --cov-report term-missing --cov=dpypelines

--- a/dpypelines/pipeline/messages/notification.py
+++ b/dpypelines/pipeline/messages/notification.py
@@ -49,9 +49,9 @@ class NopNotifier(BasePipelineNotifier):
 
 class PipelineNotifier(BasePipelineNotifier):
     def __init__(self, webhook_url, process_start_time=None):
-        assert (
-            webhook_url is not None
-        ), "Unable to find required environment variable to populate webhook_url argument"
+        assert webhook_url is not None, (
+            "Unable to find required environment variable to populate webhook_url argument"
+        )
         self.client = SlackMessenger(webhook_url)
         self.notification_postfix = os.environ.get("NOTIFICATION_POSTFIX", "")
         self.process_start_time = process_start_time

--- a/dpypelines/pipeline/messages/utils.py
+++ b/dpypelines/pipeline/messages/utils.py
@@ -55,7 +55,7 @@ def get_submitter_email(manifest_dict: dict) -> str:
 
     if manifest_dict["manifestVersion"] != 1:
         raise ValueError(
-            f'The manifest version does not match required version(which should be 1) suppllied version: {manifest_dict["manifestVersion"]}.'
+            f"The manifest version does not match required version(which should be 1) suppllied version: {manifest_dict['manifestVersion']}."
         )
 
     if submitter_email is None:

--- a/dpypelines/pipeline/transforms/sdmx/generate_versions_metadata.py
+++ b/dpypelines/pipeline/transforms/sdmx/generate_versions_metadata.py
@@ -9,7 +9,6 @@ from dpypelines.pipeline.transforms.utils import pathify, set_key
 def generate_versions_metadata(
     transformedCSV, outputPath, metadataTemplate=False, structureXML=False, config=False
 ):
-
     # Read in Structure XML provided with the SDMX and tidyCSV we created earlier in the transform
     if structureXML:
         with open(structureXML, "r") as file:

--- a/dpypelines/pipeline/transforms/sdmx/generic/v21/prototype/v1.py
+++ b/dpypelines/pipeline/transforms/sdmx/generic/v21/prototype/v1.py
@@ -16,7 +16,6 @@ from dpypelines.pipeline.transforms.validate_transform_v21 import (
 
 
 def xmlToCsvSDMX2_1(input_path, output_path):
-
     check_read_in_sdmx(input_path)  # transform validation
 
     # Converting the XML file into a giant dictionary from the nested header dictionary

--- a/dpypelines/pipeline/transforms/sdmx/v1.py
+++ b/dpypelines/pipeline/transforms/sdmx/v1.py
@@ -18,7 +18,6 @@ from dpypelines.pipeline.transforms.sdmx.generic.v21.prototype.v1 import xmlToCs
 
 
 def sdmx_compact_2_0_prototype_1(input_file: Path):
-
     csv_out = Path("data.csv")
     metadata_out = Path("metadata.json")
 
@@ -29,7 +28,6 @@ def sdmx_compact_2_0_prototype_1(input_file: Path):
 
 
 def sdmx_compact_2_1_prototype(input_file: Path):
-
     csv_out = Path("data.csv")
     metadata_out = Path("metadata.json")
 

--- a/dpypelines/pipeline/transforms/sdmx/v20.py
+++ b/dpypelines/pipeline/transforms/sdmx/v20.py
@@ -7,7 +7,6 @@ from dpypelines.pipeline.transforms.sdmx.generate_versions_metadata import (
 
 
 def sdmx_compact_2_0_prototype_1(input_file: Path):
-
     csv_out = Path("data.csv")
     metadata_out = Path("metadata.json")
 

--- a/dpypelines/pipeline/transforms/sdmx/v21.py
+++ b/dpypelines/pipeline/transforms/sdmx/v21.py
@@ -7,7 +7,6 @@ from dpypelines.pipeline.transforms.sdmx.generic.v21.prototype.v1 import xmlToCs
 
 
 def sdmx_generic_2_1_prototype_1(input_file: Path):
-
     csv_out = Path("data.csv")
     metadata_out = Path("metadata.json")
 

--- a/dpypelines/pipeline/transforms/validate_csv.py
+++ b/dpypelines/pipeline/transforms/validate_csv.py
@@ -27,9 +27,9 @@ def _correct_columns_exist(csv_path: Path, columns: List[str]):
     """
     df = pd.read_csv(csv_path, nrows=0)  # reading in columns only
 
-    assert len(df.columns) == len(
-        columns
-    ), f"Number of columns in csv file ({len(df.columns)}) does not match len of expected columns ({len(columns)})"
+    assert len(df.columns) == len(columns), (
+        f"Number of columns in csv file ({len(df.columns)}) does not match len of expected columns ({len(columns)})"
+    )
 
     for col in columns:
         assert col in df.columns, f"Expect column {col} not found in csv file"
@@ -49,15 +49,15 @@ def _dataframe_has_no_blanks(
     if check_specific_columns is None:
         columns_to_check = list(df.columns)
     else:
-        assert isinstance(
-            check_specific_columns, list
-        ), "check_specific_columns kwarg must be a list"
+        assert isinstance(check_specific_columns, list), (
+            "check_specific_columns kwarg must be a list"
+        )
 
         # confirm all columns in check_specific_columns are in df
         for col in check_specific_columns:
-            assert (
-                col in df.columns
-            ), f"{col} in check_specific_columns not found in dataframe"
+            assert col in df.columns, (
+                f"{col} in check_specific_columns not found in dataframe"
+            )
 
         columns_to_check = check_specific_columns
 
@@ -79,9 +79,9 @@ def _dataframe_has_no_duplicates(df: pd.DataFrame):
     """
     given a df confirm that there are no duplicate values
     """
-    assert len(df) == len(
-        df.drop_duplicates()
-    ), "Found duplicate rows in the dataframe, failed validation"
+    assert len(df) == len(df.drop_duplicates()), (
+        "Found duplicate rows in the dataframe, failed validation"
+    )
 
 
 def generated_dataframe_slices(csv_path: Path, chunk_size: Optional[int] = 5000):

--- a/dpypelines/pipeline/transforms/validate_transform_v20.py
+++ b/dpypelines/pipeline/transforms/validate_transform_v20.py
@@ -14,9 +14,9 @@ def get_number_of_obs_from_xml_file(xml_file: Path):
     # uses 'na_:Obs' as an identifier that a line has an observation
     with open(xml_file) as f:
         number_of_obs = sum(1 for line in f if "na_:Obs" in line)
-    assert (
-        number_of_obs != 0
-    ), "could not count any observations, likely due to incorrect xml format"
+    assert number_of_obs != 0, (
+        "could not count any observations, likely due to incorrect xml format"
+    )
     return number_of_obs
 
 
@@ -39,9 +39,9 @@ def check_header_info(header: dict):
         "Extracted",
         "Source",
     ]
-    assert len(expected_keys) == len(
-        header
-    ), f"was expecting header of size ({len(expected_keys)})"
+    assert len(expected_keys) == len(header), (
+        f"was expecting header of size ({len(expected_keys)})"
+    )
     for key in header.keys():
         assert key in expected_keys, f"{key} is not expected in header"
 
@@ -50,17 +50,17 @@ def check_header_unpacked(header_dict: dict):
     # checks that the headers have been unpacked correctly
     assert isinstance(header_dict, dict), "function was expecting a dict"
     for key in header_dict:
-        assert isinstance(
-            header_dict[key], str
-        ), "unpacked header_dict is not fully unpacked"
+        assert isinstance(header_dict[key], str), (
+            "unpacked header_dict is not fully unpacked"
+        )
 
 
 def check_xml_type(data_As_dict: dict):
     # check that the xml type is 'CompactData'
     assert len(data_As_dict.keys()) == 1, "xml format looks incorrect"
-    assert (
-        "CompactData" in data_As_dict.keys()
-    ), "could not find 'CompactData' in xml data; file is not smx v2.0"
+    assert "CompactData" in data_As_dict.keys(), (
+        "could not find 'CompactData' in xml data; file is not smx v2.0"
+    )
 
 
 def check_read_in_sdmx(xml_file: Path):
@@ -81,9 +81,9 @@ def check_length_of_dict_is_expected_length(data_dict: dict, no_of_expected_obs:
     # checks if each value in a dict are the expected lengths
     # the expected length is the number of obs found using get_number_of_obs_from_xml_file()
     for key in data_dict:
-        assert (
-            len(data_dict[key]) == no_of_expected_obs
-        ), f"expected length of {key} is not {no_of_expected_obs}"
+        assert len(data_dict[key]) == no_of_expected_obs, (
+            f"expected length of {key} is not {no_of_expected_obs}"
+        )
 
 
 def check_length_of_dataframe_is_expected_length(
@@ -91,9 +91,9 @@ def check_length_of_dataframe_is_expected_length(
 ):
     # checks if dataframe is the expected length
     # the expected length is the number of obs found using get_number_of_obs_from_xml_file()
-    assert (
-        len(dataframe) == no_of_expected_obs
-    ), f"expected length of dataframe is not {no_of_expected_obs}"
+    assert len(dataframe) == no_of_expected_obs, (
+        f"expected length of dataframe is not {no_of_expected_obs}"
+    )
 
 
 def check_columns_of_dataframes_are_unique(
@@ -102,14 +102,14 @@ def check_columns_of_dataframes_are_unique(
     # checks that each column of the 3 dataframes are unique
     # duplicate column names could result in overriding data
     for column in series_columns:
-        assert (
-            column not in obs_columns
-        ), f"{column} is duplicated in series_frame and obs_frame"
-        assert (
-            column not in header_columns
-        ), f"{column} is duplicated in series_frame and header_frame"
+        assert column not in obs_columns, (
+            f"{column} is duplicated in series_frame and obs_frame"
+        )
+        assert column not in header_columns, (
+            f"{column} is duplicated in series_frame and header_frame"
+        )
 
     for column in obs_columns:
-        assert (
-            column not in header_columns
-        ), f"{column} is duplicated in obs_frame and header_frame"
+        assert column not in header_columns, (
+            f"{column} is duplicated in obs_frame and header_frame"
+        )

--- a/dpypelines/pipeline/transforms/validate_transform_v21.py
+++ b/dpypelines/pipeline/transforms/validate_transform_v21.py
@@ -19,9 +19,9 @@ def check_read_in_sdmx(xml_file: Path):
 def check_xml_type(data: dict):
     # check that the xml type is 'GenericData'
     assert len(data.keys()) == 1, "xml format looks incorrect"
-    assert (
-        "message:GenericData" in data.keys()
-    ), "could not find 'GenericData' in xml data; therefore, file is not sdmx v2.1"
+    assert "message:GenericData" in data.keys(), (
+        "could not find 'GenericData' in xml data; therefore, file is not sdmx v2.1"
+    )
 
 
 def check_header_info(header: dict):
@@ -40,9 +40,9 @@ def check_header_info(header: dict):
         "Extracted",
         "Source",
     ]
-    assert len(expected_keys) == len(
-        header
-    ), f"was expecting header of size ({len(expected_keys)})"
+    assert len(expected_keys) == len(header), (
+        f"was expecting header of size ({len(expected_keys)})"
+    )
     for key in header.keys():
         assert key in expected_keys, f"{key} is not expected in header"
 
@@ -52,9 +52,9 @@ def get_number_of_obs_from_xml_file(xml_file: Path):
     # uses 'na_:Obs' as an identifier that a line has an observation
     with open(xml_file) as f:
         number_of_obs = sum(1 for line in f if "generic:ObsValue" in line)
-    assert (
-        number_of_obs != 0
-    ), "could not count any observations, likely due to incorrect xml format"
+    assert number_of_obs != 0, (
+        "could not count any observations, likely due to incorrect xml format"
+    )
     return number_of_obs
 
 
@@ -62,9 +62,9 @@ def check_header_unpacked(header_dict: dict):
     # checks that the headers have been unpacked correctly
     assert isinstance(header_dict, dict), "function was expecting a dict"
     for key in header_dict:
-        assert isinstance(
-            header_dict[key], str
-        ), "unpacked header_dict is not fully unpacked"
+        assert isinstance(header_dict[key], str), (
+            "unpacked header_dict is not fully unpacked"
+        )
 
 
 def check_length_of_dataframe_is_expected_length(
@@ -72,18 +72,18 @@ def check_length_of_dataframe_is_expected_length(
 ):
     # checks if dataframe is the expected length
     # the expected length is the number of obs found using get_number_of_obs_from_xml_file()
-    assert (
-        len(dataframe) == no_of_expected_obs
-    ), f"expected length of dataframe is not {no_of_expected_obs}"
+    assert len(dataframe) == no_of_expected_obs, (
+        f"expected length of dataframe is not {no_of_expected_obs}"
+    )
 
 
 def check_columns_of_dataframes_are_unique(
     obs_columns: pd.Index, header_columns: pd.Index
 ):
     for column in obs_columns:
-        assert (
-            column not in header_columns
-        ), f"{column} is duplicated in obs_frame and header_frame"
+        assert column not in header_columns, (
+            f"{column} is duplicated in obs_frame and header_frame"
+        )
 
 
 def check_tidy_data_columns(df_columns: pd.Index):
@@ -98,9 +98,9 @@ def check_obs_dicts_have_same_keys(obs_dict: List):
     # checks each item in obs_dicts has same length and same keys
     first_dict = obs_dict[0]
     for item in obs_dict:
-        assert len(first_dict) == len(
-            item
-        ), "not all items in obs_dicts are the same length"
-        assert (
-            first_dict.keys() == item.keys()
-        ), "not all keys in obs_dicts are the same"
+        assert len(first_dict) == len(item), (
+            "not all items in obs_dicts are the same length"
+        )
+        assert first_dict.keys() == item.keys(), (
+            "not all keys in obs_dicts are the same"
+        )

--- a/dpypelines/pipeline/utils.py
+++ b/dpypelines/pipeline/utils.py
@@ -340,10 +340,7 @@ def upload_files(files_to_upload):
     upload_url = JobConfiguration().upload_service_url
     dataset_api_url = JobConfiguration().dataset_api_url
     if not upload_url or not dataset_api_url:
-        err_msg = (
-            f"Required variables not set: "
-            f"UPLOAD_SERVICE_URL: {upload_url}, DATASET_API_URL: {dataset_api_url}."
-        )
+        err_msg = f"Required variables not set: UPLOAD_SERVICE_URL: {upload_url}, DATASET_API_URL: {dataset_api_url}."
         raise EnvironmentError(err_msg)
 
     upload_client = UploadServiceClient(upload_url)

--- a/poetry.lock
+++ b/poetry.lock
@@ -33,64 +33,19 @@ files = [
 ]
 
 [[package]]
-name = "black"
-version = "24.10.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812"},
-    {file = "black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea"},
-    {file = "black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f"},
-    {file = "black-24.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"},
-    {file = "black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad"},
-    {file = "black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50"},
-    {file = "black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392"},
-    {file = "black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175"},
-    {file = "black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3"},
-    {file = "black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65"},
-    {file = "black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f"},
-    {file = "black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8"},
-    {file = "black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981"},
-    {file = "black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b"},
-    {file = "black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2"},
-    {file = "black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b"},
-    {file = "black-24.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd"},
-    {file = "black-24.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:63f626344343083322233f175aaf372d326de8436f5928c042639a4afbbf1d3f"},
-    {file = "black-24.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfa1d0cb6200857f1923b602f978386a3a2758a65b52e0950299ea014be6800"},
-    {file = "black-24.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cd9c95431d94adc56600710f8813ee27eea544dd118d45896bb734e9d7a0dc7"},
-    {file = "black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d"},
-    {file = "black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.10)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "boto3"
-version = "1.37.24"
+version = "1.37.34"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "boto3-1.37.24-py3-none-any.whl", hash = "sha256:2f2b8f82a5d7f89283973bf2cab771b90c09348799e78b2a25c60cd22c443514"},
-    {file = "boto3-1.37.24.tar.gz", hash = "sha256:1d3c6fc63a9efba0af8b531ec6b7f7c6b0ef197bf3dcd875f03c9097ac68b58f"},
+    {file = "boto3-1.37.34-py3-none-any.whl", hash = "sha256:586bfa72a00601c04067f9adcbb08ecaf63b05b7d731103f33cb2ce0d6950b1b"},
+    {file = "boto3-1.37.34.tar.gz", hash = "sha256:94ca07328474db3fa605eb99b011512caa73f7161740d365a1f00cfebfb6dd90"},
 ]
 
 [package.dependencies]
-botocore = ">=1.37.24,<1.38.0"
+botocore = ">=1.37.34,<1.38.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.11.0,<0.12.0"
 
@@ -99,14 +54,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.37.24"
+version = "1.37.34"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "botocore-1.37.24-py3-none-any.whl", hash = "sha256:f1a55332cca85a6556af8941cccdaf5d2d00336647d9e89f31174f2361ffb4f2"},
-    {file = "botocore-1.37.24.tar.gz", hash = "sha256:a0bcc3c376a371f2c11afcbcc9917010c1c0a701d0e45d1ea3ec3bddeb06a8ff"},
+    {file = "botocore-1.37.34-py3-none-any.whl", hash = "sha256:bd9af0db1097befd2028ba8525e32cacc04f26ccb9dbd5d48d6ecd05bc16c27a"},
+    {file = "botocore-1.37.34.tar.gz", hash = "sha256:2909b6dbf9c90347c71a6fa0364acee522d6a7664f13d6f7996c9dd1b1f46fac"},
 ]
 
 [package.dependencies]
@@ -244,28 +199,13 @@ files = [
 ]
 
 [[package]]
-name = "click"
-version = "8.1.8"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
-    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
-markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
+markers = "sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -521,21 +461,6 @@ files = [
 ]
 
 [[package]]
-name = "isort"
-version = "5.13.2"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.8.0"
-groups = ["dev"]
-files = [
-    {file = "isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"},
-    {file = "isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.6)"]
-
-[[package]]
 name = "jmespath"
 version = "1.0.1"
 description = "JSON Matching Expressions"
@@ -583,18 +508,6 @@ files = [
 
 [package.dependencies]
 referencing = ">=0.31.0"
-
-[[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-description = "Type system extensions for programs checked with the mypy type checker."
-optional = false
-python-versions = ">=3.5"
-groups = ["dev"]
-files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
-]
 
 [[package]]
 name = "nodeenv"
@@ -769,18 +682,6 @@ test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.9.2)"]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
-
-[[package]]
 name = "platformdirs"
 version = "4.3.7"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
@@ -834,43 +735,43 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "8.3.5"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
-    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
+    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
 ]
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<2.0"
+pluggy = ">=1.5,<2"
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-cov"
-version = "4.1.0"
+version = "6.1.1"
 description = "Pytest plugin for measuring coverage."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
-    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
+    {file = "pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde"},
+    {file = "pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a"},
 ]
 
 [package.dependencies]
-coverage = {version = ">=5.2.1", extras = ["toml"]}
+coverage = {version = ">=7.5", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "python-dateutil"
@@ -1169,29 +1070,30 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.3.7"
+version = "0.11.5"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.3.7-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:0e8377cccb2f07abd25e84fc5b2cbe48eeb0fea9f1719cad7caedb061d70e5ce"},
-    {file = "ruff-0.3.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:15a4d1cc1e64e556fa0d67bfd388fed416b7f3b26d5d1c3e7d192c897e39ba4b"},
-    {file = "ruff-0.3.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d28bdf3d7dc71dd46929fafeec98ba89b7c3550c3f0978e36389b5631b793663"},
-    {file = "ruff-0.3.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:379b67d4f49774ba679593b232dcd90d9e10f04d96e3c8ce4a28037ae473f7bb"},
-    {file = "ruff-0.3.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c060aea8ad5ef21cdfbbe05475ab5104ce7827b639a78dd55383a6e9895b7c51"},
-    {file = "ruff-0.3.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:ebf8f615dde968272d70502c083ebf963b6781aacd3079081e03b32adfe4d58a"},
-    {file = "ruff-0.3.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d48098bd8f5c38897b03604f5428901b65e3c97d40b3952e38637b5404b739a2"},
-    {file = "ruff-0.3.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:da8a4fda219bf9024692b1bc68c9cff4b80507879ada8769dc7e985755d662ea"},
-    {file = "ruff-0.3.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c44e0149f1d8b48c4d5c33d88c677a4aa22fd09b1683d6a7ff55b816b5d074f"},
-    {file = "ruff-0.3.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3050ec0af72b709a62ecc2aca941b9cd479a7bf2b36cc4562f0033d688e44fa1"},
-    {file = "ruff-0.3.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a29cc38e4c1ab00da18a3f6777f8b50099d73326981bb7d182e54a9a21bb4ff7"},
-    {file = "ruff-0.3.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b15cc59c19edca917f51b1956637db47e200b0fc5e6e1878233d3a938384b0b"},
-    {file = "ruff-0.3.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e491045781b1e38b72c91247cf4634f040f8d0cb3e6d3d64d38dcf43616650b4"},
-    {file = "ruff-0.3.7-py3-none-win32.whl", hash = "sha256:bc931de87593d64fad3a22e201e55ad76271f1d5bfc44e1a1887edd0903c7d9f"},
-    {file = "ruff-0.3.7-py3-none-win_amd64.whl", hash = "sha256:5ef0e501e1e39f35e03c2acb1d1238c595b8bb36cf7a170e7c1df1b73da00e74"},
-    {file = "ruff-0.3.7-py3-none-win_arm64.whl", hash = "sha256:789e144f6dc7019d1f92a812891c645274ed08af6037d11fc65fcbc183b7d59f"},
-    {file = "ruff-0.3.7.tar.gz", hash = "sha256:d5c1aebee5162c2226784800ae031f660c350e7a3402c4d1f8ea4e97e232e3ba"},
+    {file = "ruff-0.11.5-py3-none-linux_armv6l.whl", hash = "sha256:2561294e108eb648e50f210671cc56aee590fb6167b594144401532138c66c7b"},
+    {file = "ruff-0.11.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac12884b9e005c12d0bd121f56ccf8033e1614f736f766c118ad60780882a077"},
+    {file = "ruff-0.11.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4bfd80a6ec559a5eeb96c33f832418bf0fb96752de0539905cf7b0cc1d31d779"},
+    {file = "ruff-0.11.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0947c0a1afa75dcb5db4b34b070ec2bccee869d40e6cc8ab25aca11a7d527794"},
+    {file = "ruff-0.11.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ad871ff74b5ec9caa66cb725b85d4ef89b53f8170f47c3406e32ef040400b038"},
+    {file = "ruff-0.11.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e6cf918390cfe46d240732d4d72fa6e18e528ca1f60e318a10835cf2fa3dc19f"},
+    {file = "ruff-0.11.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:56145ee1478582f61c08f21076dc59153310d606ad663acc00ea3ab5b2125f82"},
+    {file = "ruff-0.11.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e5f66f8f1e8c9fc594cbd66fbc5f246a8d91f916cb9667e80208663ec3728304"},
+    {file = "ruff-0.11.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80b4df4d335a80315ab9afc81ed1cff62be112bd165e162b5eed8ac55bfc8470"},
+    {file = "ruff-0.11.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3068befab73620b8a0cc2431bd46b3cd619bc17d6f7695a3e1bb166b652c382a"},
+    {file = "ruff-0.11.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5da2e710a9641828e09aa98b92c9ebbc60518fdf3921241326ca3e8f8e55b8b"},
+    {file = "ruff-0.11.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ef39f19cb8ec98cbc762344921e216f3857a06c47412030374fffd413fb8fd3a"},
+    {file = "ruff-0.11.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b2a7cedf47244f431fd11aa5a7e2806dda2e0c365873bda7834e8f7d785ae159"},
+    {file = "ruff-0.11.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:81be52e7519f3d1a0beadcf8e974715b2dfc808ae8ec729ecfc79bddf8dbb783"},
+    {file = "ruff-0.11.5-py3-none-win32.whl", hash = "sha256:e268da7b40f56e3eca571508a7e567e794f9bfcc0f412c4b607931d3af9c4afe"},
+    {file = "ruff-0.11.5-py3-none-win_amd64.whl", hash = "sha256:6c6dc38af3cfe2863213ea25b6dc616d679205732dc0fb673356c2d69608f800"},
+    {file = "ruff-0.11.5-py3-none-win_arm64.whl", hash = "sha256:67e241b4314f4eacf14a601d586026a962f4002a475aa702c69980a38087aa4e"},
+    {file = "ruff-0.11.5.tar.gz", hash = "sha256:cae2e2439cb88853e421901ec040a758960b576126dab520fa08e9de431d1bef"},
 ]
 
 [[package]]
@@ -1244,14 +1146,14 @@ typing = ["mypy (>=1.4)", "rich", "twisted"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.13.0"
+version = "4.13.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "typing_extensions-4.13.0-py3-none-any.whl", hash = "sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5"},
-    {file = "typing_extensions-4.13.0.tar.gz", hash = "sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b"},
+    {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
+    {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
 ]
 
 [[package]]
@@ -1280,14 +1182,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.4.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
-    {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
+    {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
+    {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
 ]
 
 [package.extras]
@@ -1319,17 +1221,17 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [[package]]
 name = "xmltodict"
-version = "0.13.0"
+version = "0.14.2"
 description = "Makes working with XML feel like you are working with JSON"
 optional = false
-python-versions = ">=3.4"
+python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"},
-    {file = "xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56"},
+    {file = "xmltodict-0.14.2-py2.py3-none-any.whl", hash = "sha256:20cc7d723ed729276e808f26fb6b3599f786cbc37e06c65e192ba77c40f20aac"},
+    {file = "xmltodict-0.14.2.tar.gz", hash = "sha256:201e7c28bb210e374999d1dde6382923ab0ed1a8a5faeece48ab525b7810a553"},
 ]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11.0,<3.12.0"
-content-hash = "2e3456b3b7b5797f05585a56a80f4924b1996cd00b6768eb29478d1d29d0c0e8"
+content-hash = "2e787d73de0c791f38c4186722c8b2b225dc2c6290f2dbfb049fc36cdd5157c3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,49 +8,43 @@ include = ["dpypelines/schemas/**/*.json"]
 
 [tool.poetry.dependencies]
 python = ">=3.11.0,<3.12.0"
-pandas = "^2.2.1"
+pandas = "^2.2.3"
 unidecode = "^1.3.8"
-xmltodict = "^0.13.0"
+xmltodict = "^0.14.2"
+python-dotenv = "^1.1.0"
 dpytools = { git = "https://github.com/ONSdigital/dp-python-tools.git", tag = "v0.6.0" }
-python-dotenv = "^1.0.1"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^7.4.4"
-black = "^24.2.0"
-isort = "^5.13.2"
-ruff = "^0.3.0"
-pytest-cov = "^4.1.0"
-docker = "^7.0.0"
-dictdiffer = "0.9.0"
+pytest = "^8.3.5"
+ruff = "^0.11.5"
+pytest-cov = "^6.1.1"
+docker = "^7.1.0"
+dictdiffer = "^0.9.0"
 pre-commit = "^4.2.0"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.isort]
-profile = "black"
-
-[tool.black]
-include = '\.pyi?$'
-extend-exclude = '''
-(
-    .*\.zip
-    | .*\.md
-    | features/
-    | docs/
-)
-'''
-
-[tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["F401"]
-
 [tool.ruff]
+# Exclude patterns (combining from both Black and Ruff)
 exclude = [
     "features/",
+    "docs/",
     ".md",
-    ".zip"
+    ".zip",
 ]
+
+[tool.ruff.lint.isort]
+case-sensitive = true
+force-single-line = false
+force-sort-within-sections = true
+combine-as-imports = false
+known-first-party = ["dpytools", "dpypelines"]
+
+# Keeping lint configuration
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
 
 [tool.semantic_release.remote]
 type = "github"
@@ -58,7 +52,6 @@ type = "github"
 [tool.semantic_release.branches]
 sandbox = { match = "sandbox", prerelease = true, prerelease_token = "rc" }
 other = { match = "staging|production", prerelease = false }
-testing = { match = "testing/", prerelease = true, prerelease_token = "rc" }
 
 [tool.semantic_release]
 tag_format = "v{version}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,6 @@ for potential_env_var_name in [
     "DE_SLACK_WEBHOOK",
     "FLORENCE_TOKEN",
 ]:
-
     env_var = os.environ.get(potential_env_var_name, None)
     if env_var is not None:
         mp.delenv(potential_env_var_name)

--- a/tests/pipelines/pipeline/shared/transforms/test_validate_csv.py
+++ b/tests/pipelines/pipeline/shared/transforms/test_validate_csv.py
@@ -124,6 +124,7 @@ def test_generated_dataframe_slices():
         "CONF_STATUS",
     ]
     chunk_size = 3
+
     len_fixture_file = 10  # has 10 rows of data
     len_final_slice = len_fixture_file % chunk_size  # returns 1
     total_number_of_slices = (
@@ -133,21 +134,21 @@ def test_generated_dataframe_slices():
 
     try:
         for df in generated_dataframe_slices(fixture_file, chunk_size=chunk_size):
-            assert (
-                type(df) == pd.DataFrame
-            ), "generated_dataframe_slices not returning a pd.DataFrame"
-            assert (
-                list(df.columns) == expected_columns_from_fixture_file
-            ), "df returing incorrect column headers"
+            assert type(df) is pd.DataFrame, (
+                "generated_dataframe_slices not returning a pd.DataFrame"
+            )
+            assert list(df.columns) == expected_columns_from_fixture_file, (
+                "df returing incorrect column headers"
+            )
             if count == total_number_of_slices:
                 # if count is 3 then length should be final slice length (1 in this case)
-                assert (
-                    len(df) == len_final_slice
-                ), f"final df should have length {len_final_slice} but found {len(df)}"
+                assert len(df) == len_final_slice, (
+                    f"final df should have length {len_final_slice} but found {len(df)}"
+                )
             else:
-                assert (
-                    len(df) == chunk_size
-                ), f"df should have length {chunk_size} but has {len(df)}"
+                assert len(df) == chunk_size, (
+                    f"df should have length {chunk_size} but has {len(df)}"
+                )
 
             count += 1
 

--- a/tests/pipelines/pipeline/test_s3_folder_received.py
+++ b/tests/pipelines/pipeline/test_s3_folder_received.py
@@ -26,7 +26,6 @@ def test_start_succeeds(
     mock_delete_s3_processing,
     mock_job_config,
 ):
-
     mock_notifier, mock_email_client = (
         MagicMock(name="notifier"),
         MagicMock(name="email_client"),

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -12,7 +12,6 @@ from dpypelines.pipeline.messages.error_handler_module import (
 @patch("dpypelines.pipeline.messages.error_handler_module.get_email_client")
 @patch("dpypelines.pipeline.messages.error_handler_module.get_notifier")
 class TestErrorHandler:
-
     def test_error_handler_fail(self, mock_notifier, mock_email_client, mock_logger):
         """Testing that `error handler` raises a `TypeError` when argument/arguments are missing"""
         print(mock_logger, mock_email_client, mock_notifier)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Chore

### What

- Update Python packages to latest versions.
- Remove `black` + `isort` packages
  - Update `ruff` config in `pyproject.toml` for linting + import sorting
  - Update `Makefile`, `.pre-commit-config.yaml`, and `.github/workflows/testing.yaml` to use `ruff` instead
- Run formatting + linting
  - There's quite a few linting changes due to the changes that `black` introduced in 2024 (that `ruff` also copies).
- Remove a semantic release testing line in the pyproject.toml that was accidentally left over.