### PR TITLE
tests: Add integration tests

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   unit-tests:
-    name: Pytest with code coverage
+    name: Unit tests with code coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
         run: poetry install
 
       - name: Pytest (make test)
-        run: poetry run pytest --cov=dpypelines --cov-report=xml
+        run: poetry run pytest --cov=dpypelines --cov-report=xml ./tests/pipelines
 
       - name: Get base branch commit
         id: get-base-ref
@@ -92,6 +92,36 @@ jobs:
         run: |
           echo "Coverage of changed code is below 80%. Please add tests to cover your changes."
           exit 1
+
+  integration-tests:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: "pip"
+
+      - name: Install poetry
+        run: pip install poetry
+
+      - name: Cache Poetry dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: ${{ runner.os }}-poetry-
+
+      - name: Install test dependencies
+        run: poetry install
+
+      - name: Pytest (make test)
+        run: poetry run pytest --cov=dpypelines --cov-report=xml ./tests/integration
 
   code-quality:
     name: Linting + formatting

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -58,7 +58,7 @@ jobs:
 
           export COVERAGE_PERCENT=$(echo $DIFF_COVER_OUTPUT | grep -o "Coverage: [0-9]\+%" | sed 's/Coverage: //' | sed 's/%//')
 
-          if [ -z "${COVERAGE_PERCENT}" ] || [ $COVERAGE_PERCENT -gt 80 ]; then
+          if [ -z "${COVERAGE_PERCENT}" ] || [ $COVERAGE_PERCENT -ge 80 ]; then
             echo "status=success" >> $GITHUB_OUTPUT
           else
             echo "status=failure" >> $GITHUB_OUTPUT

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,15 @@ fmt: install ## (Format) - runs Ruff against the codebase (auto triggered on pre
 lint: install ## Run the ruff python linter
 	poetry run ruff check --fix
 
+tests-unit: install
+	poetry run pytest --cov-report term-missing --cov=dpypelines ./tests/pipelines
+
+tests-integration: install
+	poetry run pytest --cov-report term-missing --cov=dpypelines ./tests/integration
+
 test: install ## Run pytest and check test coverage
-	poetry run pytest --cov-report term-missing --cov=dpypelines
+	make tests-unit
+	make tests-integration
 
 deploy:
 	./buildpackage.sh

--- a/dpypelines/pipeline/config/job_configuration.py
+++ b/dpypelines/pipeline/config/job_configuration.py
@@ -13,38 +13,38 @@ from dpypelines.pipeline.config.secret_mapping import SecretMapping
 def get_secret_name() -> str:
     return f"dp-{os.environ.get('ENVIRONMENT', 'sandbox')}-secrets"
 
+def get_default_environment_variables_config():
+    """
+    Environment variables to retrieve
+    """
+    return [
+        # Environment var name, JobConfiguration attribute, default value
+        ("SKIP_DATA_UPLOAD", "skip_data_upload", False),
+        ("DISABLE_NOTIFICATIONS", "disable_notifications", False),
+        ("DISABLE_EMAILS", "disable_emails", False),
+    ]
+
+def get_default_secrets_config():
+    """
+    Secrets to retrieve from AWS Secrets Manager
+    """
+    return [
+        SecretConfig(
+            secret_id=get_secret_name(),
+            mappings=[
+                SecretMapping("DATASET_API_URL", "dataset_api_url"),
+                SecretMapping("UPLOAD_SERVICE_URL", "upload_service_url"),
+                SecretMapping("DE_SLACK_WEBHOOK", "de_slack_webhook"),
+                SecretMapping("SERVICE_TOKEN_FOR_UPLOAD", "service_token_for_upload"),
+                SecretMapping("SES_EMAIL_IDENTITY", "ses_email_identity"),
+                SecretMapping(
+                    "LAMBDA_FAILURE_SLACK_WEBHOOK", "lambda_failure_slack_webhook"
+                ),
+            ],
+        )
+    ]
 
 logger = DpLogger("data-ingress-pipeline")
-
-"""
-Secrets to retrieve from AWS Secrets Manager
-"""
-secrets_config = [
-    SecretConfig(
-        secret_id=get_secret_name(),
-        mappings=[
-            SecretMapping("DATASET_API_URL", "dataset_api_url"),
-            SecretMapping("UPLOAD_SERVICE_URL", "upload_service_url"),
-            SecretMapping("DE_SLACK_WEBHOOK", "de_slack_webhook"),
-            SecretMapping("SERVICE_TOKEN_FOR_UPLOAD", "service_token_for_upload"),
-            SecretMapping("SES_EMAIL_IDENTITY", "ses_email_identity"),
-            SecretMapping(
-                "LAMBDA_FAILURE_SLACK_WEBHOOK", "lambda_failure_slack_webhook"
-            ),
-        ],
-    )
-]
-
-"""
-Environment variables to retrieve
-"""
-environment_variables_config = [
-    # Environment var name, JobConfiguration attribute, default value
-    ("SKIP_DATA_UPLOAD", "skip_data_upload", False),
-    ("DISABLE_NOTIFICATIONS", "disable_notifications", False),
-    ("DISABLE_EMAILS", "disable_emails", False),
-]
-
 
 class JobConfiguration:
     """
@@ -75,15 +75,15 @@ class JobConfiguration:
 
     def __init__(
         self,
-        secrets_config: List[tuple] = secrets_config,
-        environment_config: List[tuple] = environment_variables_config,
+        secrets_config: Optional[List[tuple]] = None,
+        environment_config: Optional[List[tuple]] = None,
         secrets_client: Optional[SecretsClient] = None,
     ):
         self.secrets_client = (
             secrets_client if secrets_client is not None else SecretsClient()
         )
-        self.secrets_config = secrets_config
-        self.environment_config = environment_config
+        self.secrets_config = secrets_config if secrets_config is not None else get_default_secrets_config()
+        self.environment_config = environment_config if environment_config is not None else get_default_environment_variables_config()
         self.load_config()
 
     def load_config(self, reload: bool = False) -> Optional[str]:

--- a/dpypelines/pipeline/config/job_configuration.py
+++ b/dpypelines/pipeline/config/job_configuration.py
@@ -13,6 +13,7 @@ from dpypelines.pipeline.config.secret_mapping import SecretMapping
 def get_secret_name() -> str:
     return f"dp-{os.environ.get('ENVIRONMENT', 'sandbox')}-secrets"
 
+
 def get_default_environment_variables_config():
     """
     Environment variables to retrieve
@@ -23,6 +24,7 @@ def get_default_environment_variables_config():
         ("DISABLE_NOTIFICATIONS", "disable_notifications", False),
         ("DISABLE_EMAILS", "disable_emails", False),
     ]
+
 
 def get_default_secrets_config():
     """
@@ -44,7 +46,9 @@ def get_default_secrets_config():
         )
     ]
 
+
 logger = DpLogger("data-ingress-pipeline")
+
 
 class JobConfiguration:
     """
@@ -82,9 +86,22 @@ class JobConfiguration:
         self.secrets_client = (
             secrets_client if secrets_client is not None else SecretsClient()
         )
-        self.secrets_config = secrets_config if secrets_config is not None else get_default_secrets_config()
-        self.environment_config = environment_config if environment_config is not None else get_default_environment_variables_config()
-        self.load_config()
+        self.secrets_config = (
+            secrets_config
+            if secrets_config is not None
+            else get_default_secrets_config()
+        )
+        self.environment_config = (
+            environment_config
+            if environment_config is not None
+            else get_default_environment_variables_config()
+        )
+        error = self.load_config()
+
+        if error is not None:
+            raise Exception(
+                f"Failed to retrieve secrets from AWS Secrets Manager. Error: {error}"
+            )
 
     def load_config(self, reload: bool = False) -> Optional[str]:
         """
@@ -113,7 +130,8 @@ class JobConfiguration:
         logger.info("Loaded JobConfiguration config")
 
     def export_env_vars(self):
-        os.environ["SERVICE_TOKEN_FOR_UPLOAD"] = self.service_token_for_upload
+        if self.service_token_for_upload:
+            os.environ["SERVICE_TOKEN_FOR_UPLOAD"] = self.service_token_for_upload
 
     def _load_env_vars(self):
         """
@@ -150,6 +168,10 @@ class JobConfiguration:
 
         for mapping in secret_mapping:
             value = secret.value.get(mapping.secret_key, None)
+            if value is None:
+                raise AttributeError(
+                    f"Secret key '{mapping.secret_key}' missing in Secret {secret.id}"
+                )
             self.__setattr__(mapping.config_attribute, value)
 
     def _load_secret(self, secret_config: SecretConfig) -> Optional[str]:

--- a/dpypelines/pipeline/messages/error_handler_module.py
+++ b/dpypelines/pipeline/messages/error_handler_module.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from dpytools.logging.logger import DpLogger
 
+from dpypelines.pipeline.messages.notification import BasePipelineNotifier
 from dpypelines.pipeline.messages.utils import get_email_client
 from dpypelines.pipeline.utils import get_notifier
 
@@ -16,6 +17,7 @@ def error_handler(
     enable_logs: bool = True,
     enable_email: bool = True,
     enable_notification: bool = True,
+    notifier: Optional[BasePipelineNotifier] = None
 ):
     """
     This function handles the errors.
@@ -44,14 +46,15 @@ def error_handler(
     # Send system notifiations if `surpress_notification` is set to false
     if enable_notification:
         try:
-            notifier = get_notifier()
+            if notifier is None:
+                notifier = get_notifier()
             notifier.failure()
         except Exception as notification_err:
             logger.error(
                 "Failed to trigger system notifications", error=notification_err
             )
 
-    raise Exception(error)
+    raise error
 
 
 def send_error_email(

--- a/dpypelines/pipeline/messages/error_handler_module.py
+++ b/dpypelines/pipeline/messages/error_handler_module.py
@@ -17,7 +17,7 @@ def error_handler(
     enable_logs: bool = True,
     enable_email: bool = True,
     enable_notification: bool = True,
-    notifier: Optional[BasePipelineNotifier] = None
+    notifier: Optional[BasePipelineNotifier] = None,
 ):
     """
     This function handles the errors.

--- a/dpypelines/pipeline/messages/utils.py
+++ b/dpypelines/pipeline/messages/utils.py
@@ -14,6 +14,7 @@ MIMETYPES = {
     ".json": "application/json",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ".csdb": "text/plain",
+    ".xls": "application/vnd.ms-excel",
 }
 
 

--- a/dpypelines/pipeline/messages/utils.py
+++ b/dpypelines/pipeline/messages/utils.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import pytz
 from dpytools.email.ses.client import SesClient
-from dpytools.utilities.utilities import str_to_bool
 from email_validator import EmailNotValidError, validate_email
 
 from dpypelines.pipeline.config import JobConfiguration

--- a/dpypelines/pipeline/messages/utils.py
+++ b/dpypelines/pipeline/messages/utils.py
@@ -13,7 +13,7 @@ MIMETYPES = {
     ".xml": "application/xml",
     ".json": "application/json",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    ".csdb": "application/octet-stream",
+    ".csdb": "text/plain",
 }
 
 

--- a/dpypelines/pipeline/messages/utils.py
+++ b/dpypelines/pipeline/messages/utils.py
@@ -27,8 +27,7 @@ def get_email_client():
     """
     Creates an email client object to be used for sending notification/error report emails.
     """
-    emails_disabled = str(JobConfiguration().disable_emails)
-    emails_disabled = str_to_bool(emails_disabled)
+    emails_disabled = JobConfiguration().disable_emails
 
     if emails_disabled:
         return NopEmailClient()

--- a/dpypelines/pipeline/utils.py
+++ b/dpypelines/pipeline/utils.py
@@ -10,7 +10,6 @@ from dpypelines.pipeline.messages.utils import (
     get_email_client,
     get_local_time,
     get_mimetype,
-    str_to_bool,
 )
 
 logger = DpLogger("data-ingress-pipelines")
@@ -22,10 +21,7 @@ def create_notifier(webhook: str, process_start_time=None):
     Enables use of webhooks from the AWS secrets manager rather than env vars.
     """
 
-    notifications_disabled = str(JobConfiguration().disable_notifications)
-    notifications_disabled = (
-        False if notifications_disabled is None else str_to_bool(notifications_disabled)
-    )
+    notifications_disabled = JobConfiguration().disable_notifications
 
     if notifications_disabled is True:
         return NopNotifier()

--- a/dpypelines/pipeline/validate_pipeline.py
+++ b/dpypelines/pipeline/validate_pipeline.py
@@ -111,4 +111,4 @@ def read_json_file(file_path: Path) -> dict:
             data = json.load(f)
         return data
     except json.JSONDecodeError as e:
-        raise ValueError(f"File is not valid JSON: {str(e)}")
+        raise ValueError(f"File {file_path} is not valid JSON: {str(e)}")

--- a/dpypelines/pipeline/validation/csv_validator.py
+++ b/dpypelines/pipeline/validation/csv_validator.py
@@ -1,34 +1,61 @@
+from io import TextIOWrapper
 from dpypelines.pipeline.validation.file_format_validator import FileFormatValidator
 from dpypelines.pipeline.validation.models import ValidationResult
-
 
 import csv
 from pathlib import Path
 
-
 class CSVValidator(FileFormatValidator):
     def __init__(self):
-        super().__init__(["csv"])
+        super().__init__(["csv", "tsv"])
 
     def validate_file_format(self, file_path: Path) -> ValidationResult:
         """
-        Validate that the file has at least one row with one column in it.
+        Validate that the file is a valid CSV.
+
+        Args:
+            file_path: Path object representing the data file to validate
+
+        Returns:
+            ValidationResult with the validation result data
         """
         try:
-            with open(file_path, "r", newline="", encoding="utf-8") as f:
-                csv_reader = csv.reader(f)
-                header = next(csv_reader, None)
+            if file_path.stat().st_size == 0:
+                return self._generate_error(file_path, f"File '{str(file_path)}' is empty")
+            
+            with open(file_path, "r", newline="", encoding="utf-8") as file:
+                valid_csv = self._try_validate_with_sniffer(file)
 
-                if not header:
-                    return self._generate_error(
-                        file_path, "No header row found in CSV file"
+                return (
+                    self._generate_success(file_path)
+                    if valid_csv
+                    else self._generate_error(
+                        file_path, f"Could not parse {file_path} as a valid CSV"
                     )
-
-                if len(header) == 0:
-                    return self._generate_error(
-                        file_path, "No columns found in CSV file"
-                    )
-
-                return self._generate_success(file_path)
+                )
         except Exception as e:
             return self._generate_error(file_path, f"CSV validation error: {str(e)}")
+
+    def _try_validate_with_sniffer(self, file: TextIOWrapper) -> bool:
+        """
+        Try to "sniff" the format of the file, and then validate based on the sniffed dialect
+
+        Args:
+            file: The open file to try to validate
+
+        Returns:
+            bool: True == valid, False == invalid
+        """
+        try:
+            csv_test_bytes = file.read(1024)  # Grab a sample of the CSV for format detection.
+            file.seek(0)  # Rewind
+            has_header = csv.Sniffer().has_header(csv_test_bytes)  # Check to see if there's a header in the file.
+            dialect = csv.Sniffer().sniff(csv_test_bytes)  # Check what kind of csv/tsv file we have.
+            inputreader = csv.reader(file, dialect)
+            if has_header:
+                next(inputreader) # Skip the header if we have one.
+            for row in inputreader:
+                print(row)
+            return True
+        except csv.Error:
+            return False

--- a/dpypelines/pipeline/validation/csv_validator.py
+++ b/dpypelines/pipeline/validation/csv_validator.py
@@ -5,6 +5,7 @@ from dpypelines.pipeline.validation.models import ValidationResult
 import csv
 from pathlib import Path
 
+
 class CSVValidator(FileFormatValidator):
     def __init__(self):
         super().__init__(["csv", "tsv"])
@@ -21,8 +22,10 @@ class CSVValidator(FileFormatValidator):
         """
         try:
             if file_path.stat().st_size == 0:
-                return self._generate_error(file_path, f"File '{str(file_path)}' is empty")
-            
+                return self._generate_error(
+                    file_path, f"File '{str(file_path)}' is empty"
+                )
+
             with open(file_path, "r", newline="", encoding="utf-8") as file:
                 valid_csv = self._try_validate_with_sniffer(file)
 
@@ -47,13 +50,19 @@ class CSVValidator(FileFormatValidator):
             bool: True == valid, False == invalid
         """
         try:
-            csv_test_bytes = file.read(1024)  # Grab a sample of the CSV for format detection.
+            csv_test_bytes = file.read(
+                1024
+            )  # Grab a sample of the CSV for format detection.
             file.seek(0)  # Rewind
-            has_header = csv.Sniffer().has_header(csv_test_bytes)  # Check to see if there's a header in the file.
-            dialect = csv.Sniffer().sniff(csv_test_bytes)  # Check what kind of csv/tsv file we have.
+            has_header = csv.Sniffer().has_header(
+                csv_test_bytes
+            )  # Check to see if there's a header in the file.
+            dialect = csv.Sniffer().sniff(
+                csv_test_bytes
+            )  # Check what kind of csv/tsv file we have.
             inputreader = csv.reader(file, dialect)
             if has_header:
-                next(inputreader) # Skip the header if we have one.
+                next(inputreader)  # Skip the header if we have one.
             for row in inputreader:
                 print(row)
             return True

--- a/dpypelines/pipeline/validation/file_validators.py
+++ b/dpypelines/pipeline/validation/file_validators.py
@@ -3,6 +3,7 @@ from .excel_validator import ExcelValidator
 from .json_validator import JSONValidator
 from .text_validator import TextValidator
 from .xml_validator import XMLValidator
+from .sqlite_validator import SQLiteValidator
 from .file_format_validator import FileFormatValidator
 
 
@@ -13,4 +14,5 @@ def get_file_validators() -> list[FileFormatValidator]:
         JSONValidator(),
         TextValidator(),
         XMLValidator(),
+        SQLiteValidator(),
     ]

--- a/dpypelines/pipeline/validation/models.py
+++ b/dpypelines/pipeline/validation/models.py
@@ -6,3 +6,15 @@ class ValidationResult:
         self.valid = valid
         self.format = format
         self.error = error
+
+    def __str__(self):
+        return f"[ValidationResult] valid:'{self.valid}', format:'{self.format}', error: {self._format_error()}"
+
+    def _format_error(self):
+        if self.error is None:
+            return "None"
+
+        return f"'{self.error}'"
+
+    def __repr__(self):
+        return self.__str__()

--- a/dpypelines/pipeline/validation/sqlite_validator.py
+++ b/dpypelines/pipeline/validation/sqlite_validator.py
@@ -1,0 +1,42 @@
+import sqlite3
+from dpypelines.pipeline.validation.file_format_validator import FileFormatValidator
+from dpypelines.pipeline.validation.models import ValidationResult
+
+
+from pathlib import Path
+
+
+class SQLiteValidator(FileFormatValidator):
+    def __init__(self):
+        super().__init__(["csdb", "sqlite", "db", "db3"])
+
+    def validate_file_format(self, file_path: Path) -> ValidationResult:
+        """
+        Validate that the file is a valid SQLite3 (or CSDB) file
+        """
+
+        "Needed because an empty file is still a valid sqlite3 DB (!) and there's no guarantees that the file was validated this way before"
+        if file_path.stat().st_size == 0:
+            return self._generate_error(file_path, "File is empty")
+
+        try:
+            conn = sqlite3.connect(f"file:{file_path}?mode=ro", uri=True)
+            cursor = conn.cursor()
+
+            result = self._verify_database_file(file_path, cursor)
+
+            cursor.close()
+            conn.close()
+
+            return result
+        except Exception as e:
+            return self._generate_error(file_path, str(e))
+
+    def _verify_database_file(
+        self, file_path: Path, cursor: sqlite3.Cursor
+    ) -> ValidationResult:
+        try:
+            cursor.execute("PRAGMA integrity_check")
+            return self._generate_success(file_path)
+        except sqlite3.DatabaseError as e:
+            return self._generate_error(file_path, str(e))

--- a/dpypelines/s3_folder_received.py
+++ b/dpypelines/s3_folder_received.py
@@ -36,6 +36,8 @@ def start(s3_object_name: str, *args, **kwargs):
         *args: Optional extra positional arguments.
         **kwargs: Optional extra keyword arguments.
     """
+    notifier = None
+    email_client = None
     try:
         # Set up clients.
         notifier, email_client = setup_clients()

--- a/dpypelines/s3_folder_received.py
+++ b/dpypelines/s3_folder_received.py
@@ -110,6 +110,6 @@ def start(s3_object_name: str, *args, **kwargs):
             enable_email=ENABLE_EMAIL,
             enable_logs=ENABLE_LOGS,
             enable_notification=ENABLE_NOTIFICATION,
-            notifier=notifier
+            notifier=notifier,
         )
         raise

--- a/dpypelines/s3_folder_received.py
+++ b/dpypelines/s3_folder_received.py
@@ -108,6 +108,6 @@ def start(s3_object_name: str, *args, **kwargs):
             enable_email=ENABLE_EMAIL,
             enable_logs=ENABLE_LOGS,
             enable_notification=ENABLE_NOTIFICATION,
+            notifier=notifier
         )
-        notifier.failure()
         raise

--- a/poetry.lock
+++ b/poetry.lock
@@ -50,7 +50,7 @@ version = "1.37.34"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "boto3-1.37.34-py3-none-any.whl", hash = "sha256:586bfa72a00601c04067f9adcbb08ecaf63b05b7d731103f33cb2ce0d6950b1b"},
     {file = "boto3-1.37.34.tar.gz", hash = "sha256:94ca07328474db3fa605eb99b011512caa73f7161740d365a1f00cfebfb6dd90"},
@@ -70,7 +70,7 @@ version = "1.37.34"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "botocore-1.37.34-py3-none-any.whl", hash = "sha256:bd9af0db1097befd2028ba8525e32cacc04f26ccb9dbd5d48d6ecd05bc16c27a"},
     {file = "botocore-1.37.34.tar.gz", hash = "sha256:2909b6dbf9c90347c71a6fa0364acee522d6a7664f13d6f7996c9dd1b1f46fac"},
@@ -95,6 +95,87 @@ files = [
     {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
     {file = "certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651"},
 ]
+
+[[package]]
+name = "cffi"
+version = "1.17.1"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+markers = "platform_python_implementation != \"PyPy\""
+files = [
+    {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
+    {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be"},
+    {file = "cffi-1.17.1-cp310-cp310-win32.whl", hash = "sha256:c9c3d058ebabb74db66e431095118094d06abf53284d9c81f27300d0e0d8bc7c"},
+    {file = "cffi-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:0f048dcf80db46f0098ccac01132761580d28e28bc0f78ae0d58048063317e15"},
+    {file = "cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401"},
+    {file = "cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b"},
+    {file = "cffi-1.17.1-cp311-cp311-win32.whl", hash = "sha256:85a950a4ac9c359340d5963966e3e0a94a676bd6245a4b55bc43949eee26a655"},
+    {file = "cffi-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:caaf0640ef5f5517f49bc275eca1406b0ffa6aa184892812030f04c2abf589a0"},
+    {file = "cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4"},
+    {file = "cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93"},
+    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3"},
+    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8"},
+    {file = "cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65"},
+    {file = "cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903"},
+    {file = "cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e"},
+    {file = "cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd"},
+    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed"},
+    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9"},
+    {file = "cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d"},
+    {file = "cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a"},
+    {file = "cffi-1.17.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:636062ea65bd0195bc012fea9321aca499c0504409f413dc88af450b57ffd03b"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7eac2ef9b63c79431bc4b25f1cd649d7f061a28808cbc6c47b534bd789ef964"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e221cf152cff04059d011ee126477f0d9588303eb57e88923578ace7baad17f9"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:31000ec67d4221a71bd3f67df918b1f88f676f1c3b535a7eb473255fdc0b83fc"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f17be4345073b0a7b8ea599688f692ac3ef23ce28e5df79c04de519dbc4912c"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2b1fac190ae3ebfe37b979cc1ce69c81f4e4fe5746bb401dca63a9062cdaf1"},
+    {file = "cffi-1.17.1-cp38-cp38-win32.whl", hash = "sha256:7596d6620d3fa590f677e9ee430df2958d2d6d6de2feeae5b20e82c00b76fbf8"},
+    {file = "cffi-1.17.1-cp38-cp38-win_amd64.whl", hash = "sha256:78122be759c3f8a014ce010908ae03364d00a1f81ab5c7f4a7a5120607ea56e1"},
+    {file = "cffi-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b2ab587605f4ba0bf81dc0cb08a41bd1c0a5906bd59243d56bad7668a6fc6c16"},
+    {file = "cffi-1.17.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:28b16024becceed8c6dfbc75629e27788d8a3f9030691a1dbf9821a128b22c36"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d599671f396c4723d016dbddb72fe8e0397082b0a77a4fab8028923bec050e8"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca74b8dbe6e8e8263c0ffd60277de77dcee6c837a3d0881d8c1ead7268c9e576"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98e3969bcff97cae1b2def8ba499ea3d6f31ddfdb7635374834cf89a1a08ecf0"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdf5ce3acdfd1661132f2a9c19cac174758dc2352bfe37d98aa7512c6b7178b3"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9755e4345d1ec879e3849e62222a18c7174d65a6a92d5b346b1863912168b595"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f1e22e8c4419538cb197e4dd60acc919d7696e5ef98ee4da4e01d3f8cfa4cc5a"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c03e868a0b3bc35839ba98e74211ed2b05d2119be4e8a0f224fba9384f1fe02e"},
+    {file = "cffi-1.17.1-cp39-cp39-win32.whl", hash = "sha256:e31ae45bc2e29f6b2abd0de1cc3b9d5205aa847cafaecb8af1476a609a2f6eb7"},
+    {file = "cffi-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662"},
+    {file = "cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824"},
+]
+
+[package.dependencies]
+pycparser = "*"
 
 [[package]]
 name = "cfgv"
@@ -300,6 +381,64 @@ files = [
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
+name = "cryptography"
+version = "44.0.2"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = "!=3.9.0,!=3.9.1,>=3.7"
+groups = ["dev"]
+files = [
+    {file = "cryptography-44.0.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:efcfe97d1b3c79e486554efddeb8f6f53a4cdd4cf6086642784fa31fc384e1d7"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29ecec49f3ba3f3849362854b7253a9f59799e3763b0c9d0826259a88efa02f1"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc821e161ae88bfe8088d11bb39caf2916562e0a2dc7b6d56714a48b784ef0bb"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3c00b6b757b32ce0f62c574b78b939afab9eecaf597c4d624caca4f9e71e7843"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7bdcd82189759aba3816d1f729ce42ffded1ac304c151d0a8e89b9996ab863d5"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4973da6ca3db4405c54cd0b26d328be54c7747e89e284fcff166132eb7bccc9c"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:4e389622b6927d8133f314949a9812972711a111d577a5d1f4bee5e58736b80a"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f514ef4cd14bb6fb484b4a60203e912cfcb64f2ab139e88c2274511514bf7308"},
+    {file = "cryptography-44.0.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1bc312dfb7a6e5d66082c87c34c8a62176e684b6fe3d90fcfe1568de675e6688"},
+    {file = "cryptography-44.0.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b721b8b4d948b218c88cb8c45a01793483821e709afe5f622861fc6182b20a7"},
+    {file = "cryptography-44.0.2-cp37-abi3-win32.whl", hash = "sha256:51e4de3af4ec3899d6d178a8c005226491c27c4ba84101bfb59c901e10ca9f79"},
+    {file = "cryptography-44.0.2-cp37-abi3-win_amd64.whl", hash = "sha256:c505d61b6176aaf982c5717ce04e87da5abc9a36a5b39ac03905c4aafe8de7aa"},
+    {file = "cryptography-44.0.2-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:8e0ddd63e6bf1161800592c71ac794d3fb8001f2caebe0966e77c5234fa9efc3"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81276f0ea79a208d961c433a947029e1a15948966658cf6710bbabb60fcc2639"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a1e657c0f4ea2a23304ee3f964db058c9e9e635cc7019c4aa21c330755ef6fd"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6210c05941994290f3f7f175a4a57dbbb2afd9273657614c506d5976db061181"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d1c3572526997b36f245a96a2b1713bf79ce99b271bbcf084beb6b9b075f29ea"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b042d2a275c8cee83a4b7ae30c45a15e6a4baa65a179a0ec2d78ebb90e4f6699"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:d03806036b4f89e3b13b6218fefea8d5312e450935b1a2d55f0524e2ed7c59d9"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c7362add18b416b69d58c910caa217f980c5ef39b23a38a0880dfd87bdf8cd23"},
+    {file = "cryptography-44.0.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8cadc6e3b5a1f144a039ea08a0bdb03a2a92e19c46be3285123d32029f40a922"},
+    {file = "cryptography-44.0.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6f101b1f780f7fc613d040ca4bdf835c6ef3b00e9bd7125a4255ec574c7916e4"},
+    {file = "cryptography-44.0.2-cp39-abi3-win32.whl", hash = "sha256:3dc62975e31617badc19a906481deacdeb80b4bb454394b4098e3f2525a488c5"},
+    {file = "cryptography-44.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:5f6f90b72d8ccadb9c6e311c775c8305381db88374c65fa1a68250aa8a9cb3a6"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:af4ff3e388f2fa7bff9f7f2b31b87d5651c45731d3e8cfa0944be43dff5cfbdb"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:0529b1d5a0105dd3731fa65680b45ce49da4d8115ea76e9da77a875396727b41"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:7ca25849404be2f8e4b3c59483d9d3c51298a22c1c61a0e84415104dacaf5562"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:268e4e9b177c76d569e8a145a6939eca9a5fec658c932348598818acf31ae9a5"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9eb9d22b0a5d8fd9925a7764a054dca914000607dff201a24c791ff5c799e1fa"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:2bf7bf75f7df9715f810d1b038870309342bff3069c5bd8c6b96128cb158668d"},
+    {file = "cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:909c97ab43a9c0c0b0ada7a1281430e4e5ec0458e6d9244c0e821bbf152f061d"},
+    {file = "cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:96e7a5e9d6e71f9f4fca8eebfd603f8e86c5225bb18eb621b2c1e50b290a9471"},
+    {file = "cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d1b3031093a366ac767b3feb8bcddb596671b3aaff82d4050f984da0c248b615"},
+    {file = "cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:04abd71114848aa25edb28e225ab5f268096f44cf0127f3d36975bdf1bdf3390"},
+    {file = "cryptography-44.0.2.tar.gz", hash = "sha256:c63454aa261a0cf0c5b4718349629793e9e634993538db841165b3df74f37ec0"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.12", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=3.0.0) ; python_version >= \"3.8\""]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox (>=2024.4.15)", "nox[uv] (>=2024.3.2) ; python_version >= \"3.8\""]
+pep8test = ["check-sdist ; python_version >= \"3.8\"", "click (>=8.0.1)", "mypy (>=1.4)", "ruff (>=0.3.6)"]
+sdist = ["build (>=1.0.0)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==44.0.2)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test-randomorder = ["pytest-randomly"]
+
+[[package]]
 name = "dictdiffer"
 version = "0.9.0"
 description = "Dictdiffer is a library that helps you to diff and patch dictionaries."
@@ -485,12 +624,30 @@ files = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+description = "A very fast and expressive template engine."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
+    {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
+]
+
+[package.dependencies]
+MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
+
+[[package]]
 name = "jmespath"
 version = "1.0.1"
 description = "JSON Matching Expressions"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
     {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
@@ -532,6 +689,125 @@ files = [
 
 [package.dependencies]
 referencing = ">=0.31.0"
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+description = "Safely add untrusted strings to HTML/XML markup."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38a9ef736c01fccdd6600705b09dc574584b89bea478200c5fbf112a6b0d5579"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:57cb5a3cf367aeb1d316576250f65edec5bb3be939e9247ae594b4bcbc317dfb"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3809ede931876f5b2ec92eef964286840ed3540dadf803dd570c3b7e13141a3b"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e07c3764494e3776c602c1e78e298937c3315ccc9043ead7e685b7f2b8d47b3c"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b424c77b206d63d500bcb69fa55ed8d0e6a3774056bdc4839fc9298a7edca171"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-win32.whl", hash = "sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:6af100e168aa82a50e186c82875a5893c5597a0c1ccdb0d8b40240b1f28b969a"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:eaa0a10b7f72326f1372a713e73c3f739b524b3af41feb43e4921cb529f5929a"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:48032821bbdf20f5799ff537c7ac3d1fba0ba032cfc06194faffa8cda8b560ff"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a9d3f5f0901fdec14d8d2f66ef7d035f2157240a433441719ac9a3fba440b13"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88b49a3b9ff31e19998750c38e030fc7bb937398b1f78cfa599aaef92d693144"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfad01eed2c2e0c01fd0ecd2ef42c492f7f93902e39a42fc9ee1692961443a29"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1225beacc926f536dc82e45f8a4d68502949dc67eea90eab715dea3a21c1b5f0"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:3169b1eefae027567d1ce6ee7cae382c57fe26e82775f460f0b2778beaad66c0"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:eb7972a85c54febfb25b5c4b4f3af4dcc731994c7da0d8a0b4a6eb0640e1d178"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-win32.whl", hash = "sha256:8c4e8c3ce11e1f92f6536ff07154f9d49677ebaaafc32db9db4620bc11ed480f"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a"},
+    {file = "markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"},
+]
+
+[[package]]
+name = "moto"
+version = "5.1.4"
+description = "A library that allows you to easily mock out tests based on AWS infrastructure"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "moto-5.1.4-py3-none-any.whl", hash = "sha256:9a19d7a64c3f03824389cfbd478b64c82bd4d8da21b242a34259360d66cd108b"},
+    {file = "moto-5.1.4.tar.gz", hash = "sha256:b339c3514f2986ebefa465671b688bdbf51796705702214b1bad46490b68507a"},
+]
+
+[package.dependencies]
+boto3 = ">=1.9.201"
+botocore = ">=1.20.88,<1.35.45 || >1.35.45,<1.35.46 || >1.35.46"
+cryptography = ">=35.0.0"
+Jinja2 = ">=2.10.1"
+py-partiql-parser = {version = "0.6.1", optional = true, markers = "extra == \"s3\""}
+python-dateutil = ">=2.1,<3.0.0"
+PyYAML = {version = ">=5.1", optional = true, markers = "extra == \"s3\""}
+requests = ">=2.5"
+responses = ">=0.15.0,<0.25.5 || >0.25.5"
+werkzeug = ">=0.5,<2.2.0 || >2.2.0,<2.2.1 || >2.2.1"
+xmltodict = "*"
+
+[package.extras]
+all = ["PyYAML (>=5.1)", "antlr4-python3-runtime", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "graphql-core", "joserfc (>=0.9.0)", "jsonpath_ng", "jsonschema", "multipart", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.6.1)", "pyparsing (>=3.0.7)", "setuptools"]
+apigateway = ["PyYAML (>=5.1)", "joserfc (>=0.9.0)", "openapi-spec-validator (>=0.5.0)"]
+apigatewayv2 = ["PyYAML (>=5.1)", "openapi-spec-validator (>=0.5.0)"]
+appsync = ["graphql-core"]
+awslambda = ["docker (>=3.0.0)"]
+batch = ["docker (>=3.0.0)"]
+cloudformation = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "graphql-core", "joserfc (>=0.9.0)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.6.1)", "pyparsing (>=3.0.7)", "setuptools"]
+cognitoidp = ["joserfc (>=0.9.0)"]
+dynamodb = ["docker (>=3.0.0)", "py-partiql-parser (==0.6.1)"]
+dynamodbstreams = ["docker (>=3.0.0)", "py-partiql-parser (==0.6.1)"]
+events = ["jsonpath_ng"]
+glue = ["pyparsing (>=3.0.7)"]
+proxy = ["PyYAML (>=5.1)", "antlr4-python3-runtime", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=2.5.1)", "graphql-core", "joserfc (>=0.9.0)", "jsonpath_ng", "multipart", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.6.1)", "pyparsing (>=3.0.7)", "setuptools"]
+quicksight = ["jsonschema"]
+resourcegroupstaggingapi = ["PyYAML (>=5.1)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "graphql-core", "joserfc (>=0.9.0)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.6.1)", "pyparsing (>=3.0.7)"]
+s3 = ["PyYAML (>=5.1)", "py-partiql-parser (==0.6.1)"]
+s3crc32c = ["PyYAML (>=5.1)", "crc32c", "py-partiql-parser (==0.6.1)"]
+server = ["PyYAML (>=5.1)", "antlr4-python3-runtime", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "flask (!=2.2.0,!=2.2.1)", "flask-cors", "graphql-core", "joserfc (>=0.9.0)", "jsonpath_ng", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.6.1)", "pyparsing (>=3.0.7)", "setuptools"]
+ssm = ["PyYAML (>=5.1)"]
+stepfunctions = ["antlr4-python3-runtime", "jsonpath_ng"]
+xray = ["aws-xray-sdk (>=0.93,!=0.96)", "setuptools"]
 
 [[package]]
 name = "nodeenv"
@@ -773,6 +1049,34 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "py-partiql-parser"
+version = "0.6.1"
+description = "Pure Python PartiQL Parser"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "py_partiql_parser-0.6.1-py2.py3-none-any.whl", hash = "sha256:ff6a48067bff23c37e9044021bf1d949c83e195490c17e020715e927fe5b2456"},
+    {file = "py_partiql_parser-0.6.1.tar.gz", hash = "sha256:8583ff2a0e15560ef3bc3df109a7714d17f87d81d33e8c38b7fed4e58a63215d"},
+]
+
+[package.extras]
+dev = ["black (==22.6.0)", "flake8", "mypy", "pytest"]
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+markers = "platform_python_implementation != \"PyPy\""
+files = [
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.3"
 description = "Data validation using Python type hints"
@@ -947,12 +1251,30 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
@@ -1118,6 +1440,26 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "responses"
+version = "0.25.7"
+description = "A utility library for mocking out the `requests` Python library."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "responses-0.25.7-py3-none-any.whl", hash = "sha256:92ca17416c90fe6b35921f52179bff29332076bb32694c0df02dcac2c6bc043c"},
+    {file = "responses-0.25.7.tar.gz", hash = "sha256:8ebae11405d7a5df79ab6fd54277f6f2bc29b2d002d0dd2d5c632594d1ddcedb"},
+]
+
+[package.dependencies]
+pyyaml = "*"
+requests = ">=2.30.0,<3.0"
+urllib3 = ">=1.25.10,<3.0"
+
+[package.extras]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "tomli ; python_version < \"3.11\"", "tomli-w", "types-PyYAML", "types-requests"]
+
+[[package]]
 name = "rpds-py"
 version = "0.24.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
@@ -1275,7 +1617,7 @@ version = "0.11.4"
 description = "An Amazon S3 Transfer Manager"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "s3transfer-0.11.4-py3-none-any.whl", hash = "sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d"},
     {file = "s3transfer-0.11.4.tar.gz", hash = "sha256:559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679"},
@@ -1293,7 +1635,7 @@ version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -1408,12 +1750,30 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "s
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8) ; platform_python_implementation == \"PyPy\" or platform_python_implementation == \"GraalVM\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\" and python_version >= \"3.13\"", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10) ; platform_python_implementation == \"CPython\""]
 
 [[package]]
+name = "werkzeug"
+version = "3.1.3"
+description = "The comprehensive WSGI web application library."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e"},
+    {file = "werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746"},
+]
+
+[package.dependencies]
+MarkupSafe = ">=2.1.1"
+
+[package.extras]
+watchdog = ["watchdog (>=2.3)"]
+
+[[package]]
 name = "xmltodict"
 version = "0.14.2"
 description = "Makes working with XML feel like you are working with JSON"
 optional = false
 python-versions = ">=3.6"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "xmltodict-0.14.2-py2.py3-none-any.whl", hash = "sha256:20cc7d723ed729276e808f26fb6b3599f786cbc37e06c65e192ba77c40f20aac"},
     {file = "xmltodict-0.14.2.tar.gz", hash = "sha256:201e7c28bb210e374999d1dde6382923ab0ed1a8a5faeece48ab525b7810a553"},
@@ -1422,4 +1782,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11.0,<3.12.0"
-content-hash = "21652b432d814f52dcb4039b79d0d9db89420b31cc52eac8cc1f992c7bb274b4"
+content-hash = "717f72fdabab404d08d7fd99e7f4d00b36c5dabb999c07591f4b272c1bbcb8c3"

--- a/poetry.lock
+++ b/poetry.lock
@@ -514,8 +514,8 @@ websockets = ["websocket-client (>=1.3.0)"]
 
 [[package]]
 name = "dpytools"
-version = "0.6.0"
-description = "Simple reusable python resources for digital publishing"
+version = "0.8.0"
+description = "Simple reusable Python resources for digital publishing"
 optional = false
 python-versions = ">=3.11, <3.12"
 groups = ["main"]
@@ -527,14 +527,15 @@ backoff = "^2.2.1"
 boto3 = "^1.37.34"
 email-validator = "^2.2.0"
 jsonschema = "^4.23.0"
+pydantic = "^2.11.3"
 requests = "^2.32.3"
 structlog = "^25.2.0"
 
 [package.source]
 type = "git"
 url = "https://github.com/ONSdigital/dp-python-tools.git"
-reference = "v0.7.0"
-resolved_reference = "406dc289d217fc4c53f2373e2cabca3b59c3335d"
+reference = "v0.8.0"
+resolved_reference = "00e1c4e79567934c7e5bff0d3c8404f2d295b717"
 
 [[package]]
 name = "email-validator"
@@ -1782,4 +1783,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11.0,<3.12.0"
-content-hash = "717f72fdabab404d08d7fd99e7f4d00b36c5dabb999c07591f4b272c1bbcb8c3"
+content-hash = "ad46e7b3c8ce29d8f61a60526bcb4aa91d4c63fab638fc54c000c35feff8b9d5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ pandas = "^2.2.3"
 unidecode = "^1.3.8"
 xmltodict = "^0.14.2"
 python-dotenv = "^1.1.0"
-dpytools = { git = "https://github.com/ONSdigital/dp-python-tools.git", tag = "v0.7.0" }
+dpytools = { git = "https://github.com/ONSdigital/dp-python-tools.git", tag = "v0.8.0" }
 pydantic = "^2.11.3"
 openpyxl = "^3.1.5"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ pytest-cov = "^6.1.1"
 docker = "^7.1.0"
 dictdiffer = "^0.9.0"
 pre-commit = "^4.2.0"
+moto = {extras = ["s3", "secretsmanager", "ses"], version = "^5.1.4"}
+pytest-mock = "^3.14.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/helpers/generators/data_file_generators.py
+++ b/tests/helpers/generators/data_file_generators.py
@@ -1,0 +1,96 @@
+import csv
+from pathlib import Path
+import sqlite3
+from typing import Optional
+import xml.etree.ElementTree as ET
+import xml.dom.minidom as minidom
+
+import pandas as pd
+
+
+def generate_xml(file_path: Path):
+    root = ET.Element("root")
+
+    # Add items
+    items = ET.SubElement(root, "items")
+
+    # Add item
+    item1 = ET.SubElement(items, "item")
+    item1.set("id", "1")
+    name1 = ET.SubElement(item1, "name")
+    name1.text = "item1"
+    value1 = ET.SubElement(item1, "value")
+    value1.text = "."
+
+    rough_string = ET.tostring(root, "utf-8")
+    reparsed = minidom.parseString(rough_string)
+    pretty_xml = reparsed.toprettyxml(indent="  ")
+
+    with open(file_path, "w") as xmlfile:
+        xmlfile.write(pretty_xml)
+
+
+def generate_excel(file_path: Path):
+    data = {"id": [1, 2], "name": ["item1", "item2"], "value": [42.5, 13.7]}
+    df = pd.DataFrame(data)
+
+    df.to_excel(file_path, index=False)
+
+
+def generate_csv(
+    file_path: Path, rows: Optional[list[list[str]]] = [["id", "name", "value"]]
+):
+    with open(file_path, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        if rows:
+            writer.writerows(rows)
+            return
+
+
+def generate_csdb(file_path: Path):
+    conn = sqlite3.connect(str(file_path))
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE dummy_table(id)")
+    conn.close()
+
+
+def generate_data_file(file_path: Path):
+    match file_path.suffix.strip("."):
+        case "csv":
+            return generate_csv(file_path)
+        case "xls":
+            return generate_excel(file_path)
+        case "xlsx":
+            return generate_excel(file_path)
+        case "csdb":
+            return generate_csdb(file_path)
+
+    raise NotImplementedError(
+        f"No data file generator for the file path {file_path} was found"
+    )
+
+
+def get_media_type_for_extension(extension: str):
+    extension = extension.strip(".")
+
+    match extension:
+        case "csv":
+            return "text/csv"
+        case "csdb":
+            return "text/plain"
+        case "xls":
+            return "application/vnd.ms-excel"
+        case "sdmx":
+            return "application/vnd.sdmx.structurespecificdata+xml"
+        case "xlsx":
+            return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        case "json":
+            return "application/json"
+        
+    print(f"Could not find matching media type for extension {extension}")
+
+    return "thisfiletype/wasnotfound"
+
+def get_media_type_for_file_name(file_name: str):
+    extension = file_name.split(".")[1]
+    return get_media_type_for_extension(extension)

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,7 @@
+# Integration tests
+
+This folder contains integration tests for the ETL Lambda Function (starting from [dpypelines/s3_folder_received.py](/tests/dpypelines/s3_folder_received.py))
+
+External services are mocked using either Pytest, unit-test, or moto. Some reusable mocks are available in the [mocks][./mocks] folder.
+
+There are various reusable helpers in the [helpers](./helpers) folder, ranging from file creation helpers, to frequently used assertion cases.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,299 @@
+import json
+import random
+import string
+import sys
+import boto3
+import pytest
+from moto import mock_aws
+from unittest.mock import MagicMock, patch
+from tests.integration.helpers.file_helpers import (
+    FileGenerationConfig,
+    create_test_zip_file,
+)
+from tests.integration.mocks.mock_dataset_api_client import (
+    MockDatasetAPIClient,
+    MockDatasetAPIClientConfig,
+)
+
+import dpypelines.pipeline.utils
+
+
+@pytest.fixture
+def reset_pipelines_module():
+    for key in list(sys.modules.keys()):
+        if key.startswith("dpypelines"):
+            del sys.modules[key]
+
+
+DEFAULT_ENV_VARS = {
+    "ENVIRONMENT": "test",
+    "DISABLE_NOTIFICATIONS": "False",
+    "DISABLE_EMAILS": "False",
+    "COMMIT_SHA": "some-git-commit",
+}
+
+
+@pytest.fixture
+def configure_env_vars(monkeypatch, reset_pipelines_module):
+    def _configure(**kwargs):
+        # Set default values
+        env_vars = DEFAULT_ENV_VARS.copy()
+
+        # Override with any provided values
+        env_vars.update(kwargs)
+
+        # Set all environment variables
+        for key, value in env_vars.items():
+            if value is not None:
+                monkeypatch.setenv(key, value)
+            else:
+                monkeypatch.delenv(key)
+
+    return _configure
+
+
+@pytest.fixture(scope="function")
+def aws_credentials(configure_env_vars, monkeypatch):
+    """
+    Mocked AWS Credentials for boto3.
+    """
+    configure_env_vars()
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-2")
+    monkeypatch.delenv("AWS_PROFILE", None)
+    yield
+
+    for key, value in DEFAULT_ENV_VARS.items():
+        monkeypatch.setenv(key, value)
+
+
+@pytest.fixture(scope="function")
+def s3_mock(aws_credentials):
+    """Fixture to set up moto S3 mock."""
+    with mock_aws():
+        yield boto3.client("s3", region_name="eu-west-2")
+
+
+@pytest.fixture(scope="function")
+def secretsmanager_mock(aws_credentials):
+    """Fixture to set up moto Secrets Manager mock."""
+    with mock_aws():
+        yield boto3.client("secretsmanager", region_name="eu-west-2")
+
+
+def email_validation_mock_implementation(email: str):
+    mock_validation_result = MagicMock()
+    mock_validation_result.normalized = email
+    mock_validation_result.original = email
+    return mock_validation_result
+
+
+@pytest.fixture(scope="function")
+def ses_client_email_validator_mock(monkeypatch, aws_credentials):
+    with patch("dpytools.email.ses.client.validate_email") as mock_email_validator:
+        mock_email_validator.side_effect = email_validation_mock_implementation
+        yield
+
+
+@pytest.fixture(scope="function")
+def utils_email_validator_mock(monkeypatch, aws_credentials):
+    with patch(
+        "dpypelines.pipeline.messages.utils.validate_email"
+    ) as mock_email_validator:
+        mock_email_validator.side_effect = email_validation_mock_implementation
+        yield
+
+
+@pytest.fixture(scope="function")
+def ses_mock(aws_credentials, ses_client_email_validator_mock):
+    """Fixture to set up moto SES mock."""
+    with mock_aws():
+        ses_client = boto3.client("ses", region_name="eu-west-2")
+        ses_client.verify_email_identity(EmailAddress="test@example.com")
+        yield ses_client
+
+
+@pytest.fixture(scope="function")
+def setup_secrets(secretsmanager_mock, aws_credentials):
+    """Setup mock secrets in AWS Secrets Manager."""
+    secret_value = {
+        "DATASET_API_URL": "http://test-dataset-api.url",
+        "UPLOAD_SERVICE_URL": "http://test-upload-service.url",
+        "DE_SLACK_WEBHOOK": "http://test-slack-webhook.url",
+        "SERVICE_TOKEN_FOR_UPLOAD": "test-service-token",
+        "SES_EMAIL_IDENTITY": "test@example.com",
+        "LAMBDA_FAILURE_SLACK_WEBHOOK": "http://test-lambda-webhook.url",
+    }
+
+    secretsmanager_mock.create_secret(
+        Name="dp-test-secrets", SecretString=json.dumps(secret_value)
+    )
+
+
+def generate_random_file_name():
+    return "".join(
+        random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits)
+        for _ in range(16)
+    )
+
+
+valid_file_config = FileGenerationConfig(True, False, False)
+
+
+@pytest.fixture(scope="function")
+def zip_file_object_key_factory(s3_mock, create_zip_file_factory, aws_credentials):
+    """Upload the test zip file to the S3 mock."""
+
+    def factory(
+        manifest_config: FileGenerationConfig = valid_file_config,
+        metadata_config: FileGenerationConfig = valid_file_config,
+        data_config: FileGenerationConfig = valid_file_config,
+        data_file_name: str = "data.csv",
+    ):
+        bucket_name = "test-pipeline-bucket"
+        zip_key = f"input/{generate_random_file_name()}.zip"
+
+        # Create the S3 bucket
+        s3_mock.create_bucket(
+            Bucket=bucket_name,
+            CreateBucketConfiguration={"LocationConstraint": "eu-west-2"},
+        )
+
+        zip_file = create_zip_file_factory(
+            manifest_config=manifest_config,
+            metadata_config=metadata_config,
+            data_config=data_config,
+            data_file_name=data_file_name,
+        )
+        # Upload the zip file
+        with open(zip_file, "rb") as f:
+            s3_mock.put_object(Bucket=bucket_name, Key=zip_key, Body=f.read())
+
+        return f"{bucket_name}/{zip_key}"
+
+    return factory
+
+
+@pytest.fixture(scope="function")
+def create_zip_file_factory(aws_credentials):
+    """Create a temporary zip file with test data for pipeline processing."""
+    created_files = []
+
+    def factory(
+        manifest_config: FileGenerationConfig,
+        metadata_config: FileGenerationConfig,
+        data_config: FileGenerationConfig,
+        data_file_name: str,
+    ):
+        zip_path = create_test_zip_file(
+            manifest_config=manifest_config,
+            metadata_config=metadata_config,
+            data_config=data_config,
+            data_file_name=data_file_name,
+        )
+        created_files.append(zip_path)
+        return zip_path
+
+    yield factory
+
+    for zip_path in created_files:
+        if zip_path.exists():
+            zip_path.unlink()
+
+
+@pytest.fixture
+def mock_api_config(aws_credentials):
+    mock_get_response = MagicMock()
+    mock_get_response.status_code = 200
+    mock_get_response.text = '{"current": {"type": "static"}}'
+
+    mock_post_json_response = MagicMock()
+    mock_post_json_response.status_code = 201
+
+    mock_get_path_response = MagicMock()
+    mock_get_path_response.status_code = 200
+
+    mock_config = MockDatasetAPIClientConfig(
+        mock_get_response=mock_get_response,
+        mock_get_path_response=mock_get_path_response,
+        mock_post_json_response=mock_post_json_response,
+    )
+    return mock_config
+
+
+@pytest.fixture(scope="function")
+def mock_api_service_in_utils(mock_api_config, aws_credentials):
+    """Mock HTTP services (Dataset API and Upload Service)."""
+    with patch("dpypelines.pipeline.dataset_api.DatasetAPIClient") as mock_dataset_api:
+        instances = []
+
+        def create_client_instance(
+            dataset_api_url=None, dataset_path=None, edition_path=None
+        ):
+            client = MockDatasetAPIClient(
+                dataset_api_url=dataset_api_url,
+                dataset_path=dataset_path,
+                edition_path=edition_path,
+                config=mock_api_config,
+            )
+            instances.append(client)
+            return client
+
+        # Set the mock class to return our factory output when instantiated
+        mock_dataset_api.side_effect = create_client_instance
+        mock_dataset_api.instances = instances
+        mock_dataset_api.mock_config = mock_api_config
+        # Return the mock class itself so tests can inspect calls
+        yield mock_dataset_api
+
+
+@pytest.fixture(scope="function")
+def mock_upload_service(aws_credentials):
+    with patch("dpypelines.pipeline.utils.UploadServiceClient") as mock_upload_service:
+        mock = MagicMock()
+        mock_upload_service.return_value = mock
+        yield mock
+
+
+@pytest.fixture(scope="function")
+def spy_notifier(mocker, reset_pipelines_module, aws_credentials, mock_slack):
+    # Save the original class before patching
+    original_notifier_class = dpypelines.pipeline.utils.PipelineNotifier
+
+    # Create a class that inherits from the original but lets us spy on methods
+    class SpyPipelineNotifier(original_notifier_class):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.client = mock_slack
+
+            success_mock = MagicMock()
+            success_mock.side_effect = super().success
+            self.success = success_mock
+
+            failure_mock = MagicMock()
+            failure_mock.side_effect = super().failure
+            self.failure = failure_mock
+
+    with patch("dpypelines.pipeline.utils.PipelineNotifier") as e:
+        instances = []
+
+        def create_notifier(*args, **kwargs):
+            instance = SpyPipelineNotifier(*args, **kwargs)
+            instances.append(instance)
+            return instance
+
+        e.side_effect = create_notifier
+        e.instances = instances
+        yield e
+
+
+@pytest.fixture(scope="function")
+def mock_slack(aws_credentials):
+    """Disable the notifier to avoid real Slack calls."""
+    with patch(
+        "dpypelines.pipeline.messages.notification.SlackMessenger"
+    ) as mock_get_notifier:
+        mock_get_notifier.msg_str.return_value = None
+        yield mock_get_notifier

--- a/tests/integration/helpers/file_helpers.py
+++ b/tests/integration/helpers/file_helpers.py
@@ -1,0 +1,192 @@
+from datetime import datetime
+import json
+from pathlib import Path
+import tempfile
+from typing import Callable, Optional
+import zipfile
+
+from tests.helpers.generators.data_file_generators import (
+    generate_data_file,
+    get_media_type_for_extension,
+)
+
+MANIFEST_FILE_NAME = "manifest.json"
+METADATA_FILE_NAME = "metadata.json"
+DATA_FILE_NAME = "data.csv"
+
+FILE_AUTHOR_EMAIL = "test@example.com"
+
+
+class FileGenerationConfig:
+    """
+    Model for configuring file generations for integrationtests
+    """
+
+    include: bool
+    invalid: bool
+    empty: bool
+    missing_field_keys: list
+    content: Optional[str]
+
+    def __init__(
+        self,
+        include: bool = True,
+        invalid: bool = False,
+        empty: bool = False,
+        missing_field_keys: list = [],
+        content: Optional[str] = None,
+    ):
+        """
+        Args:
+            include: Include the file this config is for
+            invalid: Generate an invalid file for this config
+            empty: Generate an empty file for this config
+            missing_field_keys: Remove these keys from the generated data
+            content: Overwrite the generation with this specific file content
+        """
+        self.include = include
+        self.invalid = invalid
+        self.empty = empty
+        self.missing_field_keys = missing_field_keys
+        self.content = content
+
+
+def write_json_file(temp_path: Path, contents: dict, file_name: str):
+    with open(temp_path / file_name, "w") as f:
+        json.dump(contents, f)
+
+
+def write_text_file(temp_path: Path, file_name: str, contents: str):
+    with open(temp_path / file_name, "w") as f:
+        f.write(contents)
+
+
+def write_empty_file(temp_path: Path, file_name: str):
+    write_text_file(temp_path, file_name, "")
+
+
+def process_config_overrides(
+    file_name: str, temp_path: Path, config: FileGenerationConfig
+):
+    """
+    Process specific overrides from the FileGenerationConfig, e.g. writing an empty file, or a file with content overrides
+
+    Args:
+        file_name: output file name
+        temp_path: Target destination
+        config: Config file file generation
+
+    Returns:
+        boolean indicating that we have written a file or not.
+    """
+    if config.empty:
+        write_empty_file(temp_path, file_name)
+        return True
+
+    if config.content:
+        write_text_file(temp_path, file_name, config.content)
+        return True
+
+    return False
+
+
+def file_generator(file_name: str, data_dict_generator: Callable[[], dict]):
+    def create_file(temp_path: Path, config: FileGenerationConfig):
+        if process_config_overrides(file_name, temp_path, config):
+            return
+
+        dict_contents = data_dict_generator()
+
+        for key in config.missing_field_keys:
+            dict_contents.pop(key)
+
+        write_json_file(temp_path, dict_contents, file_name)
+
+    return create_file
+
+
+def generate_manifest_dict():
+    return {
+        "submission_contacts": [
+            {"email": FILE_AUTHOR_EMAIL},
+        ],
+        "metadata_file": "metadata.json",
+    }
+
+
+def create_manifest(temp_path: Path, config: FileGenerationConfig):
+    return file_generator(MANIFEST_FILE_NAME, generate_manifest_dict)(temp_path, config)
+
+
+def generate_distribution_for_file_name(file_name: str) -> dict:
+    file_extension = file_name.split(".")[1]
+
+    return {
+        "title": "CSV Distribution",
+        "download_url": f"https://download.ons.gov.uk/{file_name}",
+        "file": file_name,
+        "media_type": get_media_type_for_extension(file_extension),
+        "format": file_extension,
+    }
+
+
+def generate_metadata_dict(data_file_name: str) -> dict:
+    distribution = generate_distribution_for_file_name(data_file_name)
+    return {
+        "dataset_id": "test-dataset",
+        "edition": "time-series",
+        "edition_title": "Edition title",
+        "release_date": datetime.now().isoformat(),
+        "distributions": [distribution],
+        "alerts": [{"type": "alert type", "description": "some alert"}],
+        "usage_notes": [{"title": "how to use me", "note": "read"}],
+        "quality_designation": "official",
+    }
+
+
+def create_metadata(temp_path: Path, config: FileGenerationConfig, data_file_name: str):
+    def generate_metadata_for_data_file():
+        return generate_metadata_dict(data_file_name)
+
+    return file_generator(METADATA_FILE_NAME, generate_metadata_for_data_file)(
+        temp_path, config
+    )
+
+
+def create_data_file(temp_path: Path, file_name: str, config: FileGenerationConfig):
+    if process_config_overrides(file_name, temp_path, config):
+        return
+
+    combined_path = temp_path / file_name
+    generate_data_file(combined_path)
+
+
+def create_zip(temp_path):
+    zip_path = Path(tempfile.mkstemp(suffix=".zip")[1])
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        for file_path in temp_path.iterdir():
+            zipf.write(file_path, arcname=file_path.name)
+    return zip_path
+
+
+def create_test_zip_file(
+    manifest_config: FileGenerationConfig,
+    metadata_config: FileGenerationConfig,
+    data_config: FileGenerationConfig,
+    data_file_name: str,
+):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        if manifest_config.include:
+            create_manifest(temp_path, manifest_config)
+
+        if metadata_config.include:
+            create_metadata(temp_path, metadata_config, data_file_name)
+
+        if data_config.include:
+            create_data_file(temp_path, data_file_name, data_config)
+
+        zip_path = create_zip(temp_path)
+
+        return zip_path

--- a/tests/integration/helpers/notification_assertion_helpers.py
+++ b/tests/integration/helpers/notification_assertion_helpers.py
@@ -1,0 +1,19 @@
+def assert_no_success_and_one_failure(spy_notifier):
+    """
+    Verifies that there was one notification client instantiated, no success notification, and one failure notification
+    """
+    assert len(spy_notifier.instances) == 1
+
+    spy_notifier_instance = spy_notifier.instances[0]
+    spy_notifier_instance.success.assert_not_called()
+    spy_notifier_instance.failure.assert_called_once()
+
+def assert_success_notification(spy_notifier):
+    """
+    Verifies that there was one notification client instantiated, one success notification, and no failure notification
+    """
+    assert len(spy_notifier.instances) == 1
+
+    spy_notifier_instance = spy_notifier.instances[0]
+    spy_notifier_instance.success.assert_called_once()
+    spy_notifier_instance.failure.assert_not_called()

--- a/tests/integration/helpers/s3_assertion_helpers.py
+++ b/tests/integration/helpers/s3_assertion_helpers.py
@@ -1,0 +1,73 @@
+from typing import Optional
+from moto import mock_aws
+import pytest
+from botocore.exceptions import ClientError
+
+
+def get_objects_in_bucket(s3_client, bucket_name: str):
+    files_in_dir = s3_client.list_objects(Bucket=bucket_name)
+    contents = files_in_dir["Contents"]
+    return contents
+
+
+def get_object_keys_in_bucket(s3_client, bucket_name: str):
+    contents = get_objects_in_bucket(s3_client, bucket_name)
+    return [content["Key"] for content in contents]
+
+
+def assert_files_exist(
+    object_keys_in_bucket: list[str], expected_files: list[str], expected_prefix: str
+):
+    for file in expected_files:
+        matching = get_matching_file(object_keys_in_bucket, file, expected_prefix)
+        assert matching is True, f"Did not find {file} in {object_keys_in_bucket}"
+
+
+def get_matching_file(object_keys: list[str], file_name: str, expected_prefix: str):
+    for key in object_keys:
+        if key.endswith(file_name) and key.startswith(expected_prefix):
+            return True
+
+    return False
+
+
+class S3ObjectFile:
+    def __init__(self, uploaded_path: str):
+        self.uploaded_path = uploaded_path
+        split_key = uploaded_path.split("/")
+        self.bucket_name = split_key[0]
+        self.initial_key_without_bucket = uploaded_path.removeprefix(
+            self.bucket_name
+        ).removeprefix("/")
+        self.file_name = split_key[-1]
+
+    @mock_aws
+    def verify_file_moved(self, s3_client):
+        with pytest.raises(ClientError) as e:
+            s3_client.head_object(
+                Bucket=self.bucket_name, Key=self.initial_key_without_bucket
+            )
+
+        assert "(404)" in str(e)
+
+    @mock_aws
+    def verify_files_in_destination(
+        self,
+        s3_client,
+        expected_files: list[str],
+        key_prefix: str,
+        expected_file_count: Optional[int] = None,
+    ):
+        object_keys_in_directory = get_object_keys_in_bucket(
+            s3_client, self.bucket_name
+        )
+        if expected_file_count is not None:
+            assert len(object_keys_in_directory) == expected_file_count, (
+                object_keys_in_directory
+            )
+        else:
+            assert len(object_keys_in_directory) == len(expected_files), (
+                object_keys_in_directory
+            )
+
+        assert_files_exist(object_keys_in_directory, expected_files, key_prefix)

--- a/tests/integration/helpers/ses_assertion_helpers.py
+++ b/tests/integration/helpers/ses_assertion_helpers.py
@@ -1,0 +1,47 @@
+from moto.core import DEFAULT_ACCOUNT_ID
+from moto.ses import ses_backends
+
+from tests.integration.helpers.file_helpers import FILE_AUTHOR_EMAIL
+
+
+def get_sent_emails():
+    ses_backend = ses_backends[DEFAULT_ACCOUNT_ID]["eu-west-2"]
+    messages = ses_backend.sent_messages
+    return messages
+
+
+def assert_no_emails_sent():
+    sent_emails = get_sent_emails()
+    assert len(sent_emails) == 0
+
+
+def assert_email_sent(expected_content_parts: list[str], expected_subject: str):
+    sent_emails = get_sent_emails()
+    assert len(sent_emails) == 1
+
+    sent_email = sent_emails[0]
+    assert sent_email.subject == expected_subject
+    assert sent_email.source == FILE_AUTHOR_EMAIL
+    for part in expected_content_parts:
+        assert part in sent_email.body
+
+
+def assert_successful_email():
+    assert_email_sent(
+        [
+            "Your pipeline submission has been processed. If there were any issues, you will receive a separate email with the details"
+        ],
+        "Pipeline Submission: Processed Successfully",
+    )
+
+
+def assert_exception_email_sent(exception_message: str):
+    sent_emails = get_sent_emails()
+    assert len(sent_emails) == 1
+
+    sent_email = sent_emails[0]
+
+    assert sent_email.source == FILE_AUTHOR_EMAIL
+    assert "ETL Pipeline error has occurred" in sent_email.subject
+    assert "An error has occurred in section" in sent_email.body
+    assert exception_message in sent_email.body

--- a/tests/integration/helpers/upload_service_assertion_helpers.py
+++ b/tests/integration/helpers/upload_service_assertion_helpers.py
@@ -1,0 +1,49 @@
+from typing import Optional
+from unittest.mock import MagicMock
+
+from tests.helpers.generators.data_file_generators import get_media_type_for_file_name
+
+DEFAULT_SUCCESSFUL_EXPECTED_CALLS = [
+    {"mimetype": "text/csv", "filename": "data.csv"},
+]
+
+
+def generate_expected_call_for_data_file_name(data_file_name: str):
+    return {
+        "mimetype": get_media_type_for_file_name(data_file_name),
+        "filename": data_file_name,
+    }
+
+
+def validate_successful_upload_service_calls(
+    mock_upload_service: MagicMock,
+    data_file_name: Optional[str] = None,
+    expected_calls: Optional[list[dict]] = None,
+):
+    if expected_calls is None and data_file_name is None:
+        expected_calls = DEFAULT_SUCCESSFUL_EXPECTED_CALLS
+    elif data_file_name and not expected_calls:
+        expected_calls = [generate_expected_call_for_data_file_name(data_file_name)]
+    elif data_file_name and expected_calls:
+        expected_calls.append(generate_expected_call_for_data_file_name(data_file_name))
+
+    upload_service_calls = mock_upload_service.upload_new.call_args_list
+
+    assert len(upload_service_calls) == 1
+
+    for expected_call in expected_calls:
+        found = False
+        for actual_call in upload_service_calls:
+            found = call_matches(expected_call, actual_call)
+            if found:
+                break
+
+        assert found is True, f"Failed to find {expected_call} in upload service calls"
+
+
+def call_matches(expected_call: dict, actual_call):
+    args = actual_call.args
+    file_matches = args[0].name == expected_call["filename"]
+    mimetype_matches = args[1] == expected_call["mimetype"]
+    found = file_matches and mimetype_matches
+    return found

--- a/tests/integration/mocks/mock_dataset_api_client.py
+++ b/tests/integration/mocks/mock_dataset_api_client.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock
+from dpytools.http.api.dataset_api_client import DatasetAPIClient
+
+
+class MockDatasetAPIClientConfig:
+    def __init__(
+        self, mock_get_response, mock_get_path_response, mock_post_json_response
+    ):
+        self.mock_get_response = mock_get_response
+        self.mock_get_path_response = mock_get_path_response
+        self.mock_post_json_response = mock_post_json_response
+
+
+def raise_for_status(mock: MagicMock):
+    if mock.status_code > 299 or mock.status_code < 200:
+        raise Exception(f"Mock error raised as mock status_code is {mock.status_code}")
+
+
+class MockDatasetAPIClient(DatasetAPIClient):
+    def __init__(
+        self,
+        dataset_api_url: str,
+        dataset_path: str,
+        edition_path: str,
+        config: MockDatasetAPIClientConfig,
+    ):
+        super().__init__(
+            dataset_api_url=dataset_api_url,
+            dataset_path=dataset_path,
+            edition_path=edition_path,
+        )
+        self.mock_config = config
+        self.get_path = MagicMock()
+        self.get_path.return_value = self.mock_config.mock_get_path_response
+
+        self.get = MagicMock()
+        self.get.return_value = self.mock_config.mock_get_response
+
+        self.post_json = MagicMock()
+        self.post_json.return_value = self.mock_config.mock_post_json_response
+
+        for mock_response in [
+            self.post_json.return_value,
+            self.get_path.return_value,
+            self.get.return_value,
+        ]:
+            self.add_raise_for_status(mock_response)
+
+    def add_raise_for_status(self, mock: MagicMock):
+        mock.raise_for_status.side_effect = lambda: raise_for_status(mock)

--- a/tests/integration/mocks/mock_notifier.py
+++ b/tests/integration/mocks/mock_notifier.py
@@ -1,0 +1,10 @@
+from unittest.mock import MagicMock
+from dpypelines.pipeline.messages.notification import PipelineNotifier
+
+
+class MockPipelineNotifier(PipelineNotifier):
+    def __init__(self, webhook_url, process_start_time=None):
+        super().__init__(webhook_url=webhook_url, process_start_time=process_start_time)
+        slack_mock = MagicMock()
+        slack_mock.msg_str.return_value = None
+        self.client = slack_mock

--- a/tests/integration/mocks/mock_s3_client.py
+++ b/tests/integration/mocks/mock_s3_client.py
@@ -1,0 +1,32 @@
+from typing import Optional
+from unittest.mock import MagicMock
+import boto3
+
+
+def create_mock_s3_client(
+    mock_s3_get: Optional[MagicMock] = None,
+    mock_s3_put: Optional[MagicMock] = None,
+    mock_s3_copy: Optional[MagicMock] = None,
+    mock_s3_delete: Optional[MagicMock] = None,
+):
+    actual_client = boto3.client("s3")
+
+    mock = MagicMock()
+
+    mock.get_object.side_effect = (
+        mock_s3_get if mock_s3_get is not None else actual_client.get_object
+    )
+    mock.put_object.side_effect = (
+        mock_s3_put if mock_s3_put is not None else actual_client.put_object
+    )
+    mock.download_fileobj.side_effect = (
+        mock_s3_get if mock_s3_get is not None else actual_client.download_fileobj
+    )
+    mock.copy_object.side_effect = (
+        mock_s3_copy if mock_s3_copy is not None else actual_client.copy_object
+    )
+    mock.delete_object.side_effect = (
+        mock_s3_delete if mock_s3_delete is not None else actual_client.delete_object
+    )
+    mock.actual_client = actual_client
+    return mock

--- a/tests/integration/test_aws_s3_errors.py
+++ b/tests/integration/test_aws_s3_errors.py
@@ -1,0 +1,309 @@
+from unittest.mock import MagicMock, patch
+import boto3
+from moto import mock_aws
+import pytest
+from tests.integration.helpers.notification_assertion_helpers import (
+    assert_no_success_and_one_failure,
+)
+from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
+from tests.integration.helpers.ses_assertion_helpers import assert_no_emails_sent
+from tests.integration.mocks.mock_s3_client import create_mock_s3_client
+from botocore.exceptions import ClientError
+
+
+@patch("boto3.Session")
+@mock_aws
+def test_s3_download_error(
+    mock_boto,
+    zip_file_object_key_factory,
+    s3_mock,
+    setup_secrets,
+    secretsmanager_mock,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """
+    Tests when S3 download object fails
+    """
+    zip_file_object_key = zip_file_object_key_factory()
+
+    error_response = {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}
+
+    def raise_exception(*args, **kwargs):
+        raise ClientError(error_response, "GetObject")
+
+    mock_get = MagicMock()
+    mock_get.side_effect = raise_exception
+    mock_s3_client = create_mock_s3_client(mock_s3_get=mock_get)
+
+    def get_moto_client_mock(*args, **kwargs):
+        if args[0] == "s3":
+            return mock_s3_client
+        return boto3.client(*args, **kwargs)
+
+    mock_boto_session = MagicMock()
+    mock_boto_session.client.side_effect = get_moto_client_mock
+    mock_boto.return_value = mock_boto_session
+
+    from dpypelines.s3_folder_received import start
+
+    with pytest.raises(ClientError) as e:
+        start(zip_file_object_key)
+
+    assert e.value.operation_name == "GetObject"
+    mock_s3_client.download_fileobj.assert_called()
+    mock_s3_client.put_object.assert_not_called()
+
+    assert len(mock_api_service_in_utils.instances) == 0
+
+    # Unexpected behaviour
+    assert_no_success_and_one_failure(spy_notifier)
+
+    mock_upload_service.upload_new.assert_not_called()
+
+    # File should still be in processing
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    head_object_result = mock_boto.head_object(
+        Bucket=uploaded_file_info.bucket_name,
+        Key=uploaded_file_info.initial_key_without_bucket,
+    )
+
+    assert "Error" not in head_object_result
+    # Not desired behaviour
+    assert_no_emails_sent()
+
+
+@patch("boto3.Session")
+@mock_aws
+def test_s3_putobject_error(
+    mock_boto,
+    zip_file_object_key_factory,
+    s3_mock,
+    setup_secrets,
+    secretsmanager_mock,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """
+    Tests when uploading file to S3 fails
+    """
+    zip_file_object_key = zip_file_object_key_factory()
+
+    error_response = {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}
+
+    def raise_exception(*args, **kwargs):
+        raise ClientError(error_response, "PutObject")
+
+    mock_put = MagicMock()
+    mock_put.side_effect = raise_exception
+    mock_s3_client = create_mock_s3_client(mock_s3_put=mock_put)
+
+    def get_moto_client_mock(*args, **kwargs):
+        if args[0] == "s3":
+            return mock_s3_client
+        return boto3.client(*args, **kwargs)
+
+    mock_boto_session = MagicMock()
+    mock_boto_session.client.side_effect = get_moto_client_mock
+    mock_boto.return_value = mock_boto_session
+
+    from dpypelines.s3_folder_received import start
+
+    with pytest.raises(ClientError) as e:
+        start(zip_file_object_key)
+
+    assert len(mock_api_service_in_utils.instances) == 0
+
+    assert e.value.operation_name == "PutObject"
+    mock_s3_client.download_fileobj.assert_called()
+    mock_s3_client.put_object.assert_called()
+
+    # Unexpected behaviour
+    spy_notifier.assert_called()
+    spy_notifier_instance = spy_notifier.instance
+    spy_notifier_instance.success.assert_not_called()
+
+    # Not desired behaviour
+    spy_notifier_instance.failure.assert_not_called()
+
+    mock_upload_service.upload_new.assert_not_called()
+
+    # File should still be in processing
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    head_object_result = mock_boto.head_object(
+        Bucket=uploaded_file_info.bucket_name,
+        Key=uploaded_file_info.initial_key_without_bucket,
+    )
+
+    assert "Error" not in head_object_result
+    # Not desired behaviour
+    assert_no_emails_sent()
+
+
+# Copy failure
+@patch("boto3.Session")
+@mock_aws
+def test_s3_copyobject_error(
+    mock_boto,
+    zip_file_object_key_factory,
+    s3_mock,
+    setup_secrets,
+    secretsmanager_mock,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """
+    Tests when uploading file to S3 fails
+    """
+    zip_file_object_key = zip_file_object_key_factory()
+
+    error_response = {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}
+
+    def raise_exception(*args, **kwargs):
+        raise ClientError(error_response, "CopyObject")
+
+    mock_copy = MagicMock()
+    mock_copy.side_effect = raise_exception
+    mock_s3_client = create_mock_s3_client(mock_s3_copy=mock_copy)
+
+    def get_moto_client_mock(*args, **kwargs):
+        if args[0] == "s3":
+            return mock_s3_client
+        return boto3.client(*args, **kwargs)
+
+    mock_boto_session = MagicMock()
+    mock_boto_session.client.side_effect = get_moto_client_mock
+    mock_boto.return_value = mock_boto_session
+
+    from dpypelines.s3_folder_received import start
+
+    with pytest.raises(ClientError) as e:
+        start(zip_file_object_key)
+
+    assert len(mock_api_service_in_utils.instances) == 0
+
+    assert e.value.operation_name == "CopyObject"
+
+    mock_s3_client.download_fileobj.assert_called()
+    mock_s3_client.put_object.assert_called()
+    mock_s3_client.copy_object.assert_called()
+
+    # Unexpected behaviour
+    spy_notifier.assert_called()
+    spy_notifier_instance = spy_notifier.instance
+    spy_notifier_instance.success.assert_not_called()
+
+    # Not desired behaviour
+    spy_notifier_instance.failure.assert_not_called()
+
+    mock_upload_service.upload_new.assert_not_called()
+
+    # File should still be in processing
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    head_object_result = mock_boto.head_object(
+        Bucket=uploaded_file_info.bucket_name,
+        Key=uploaded_file_info.initial_key_without_bucket,
+    )
+
+    assert "Error" not in head_object_result
+    # Not desired behaviour
+    assert_no_emails_sent()
+
+
+# Delete failure
+@patch("boto3.Session")
+@mock_aws
+def test_s3_deleteobject_error(
+    mock_boto,
+    zip_file_object_key_factory,
+    s3_mock,
+    setup_secrets,
+    secretsmanager_mock,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """
+    Tests when deleting an S3 files
+    """
+    zip_file_object_key = zip_file_object_key_factory()
+
+    error_response = {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}
+
+    def raise_exception(*args, **kwargs):
+        raise ClientError(error_response, "DeleteObject")
+
+    mock_delete = MagicMock()
+    mock_delete.side_effect = raise_exception
+    mock_s3_client = create_mock_s3_client(mock_s3_delete=mock_delete)
+
+    def get_moto_client_mock(*args, **kwargs):
+        if args[0] == "s3":
+            return mock_s3_client
+        return boto3.client(*args, **kwargs)
+
+    mock_boto_session = MagicMock()
+    mock_boto_session.client.side_effect = get_moto_client_mock
+    mock_boto.return_value = mock_boto_session
+
+    from dpypelines.s3_folder_received import start
+
+    with pytest.raises(ClientError) as e:
+        start(zip_file_object_key)
+
+    assert len(mock_api_service_in_utils.instances) == 0
+
+    assert e.value.operation_name == "DeleteObject"
+
+    mock_s3_client.download_fileobj.assert_called()
+    mock_s3_client.put_object.assert_called()
+    mock_s3_client.copy_object.assert_called()
+    mock_s3_client.delete_object.assert_called()
+
+    # Unexpected behaviour
+    spy_notifier.assert_called()
+    spy_notifier_instance = spy_notifier.instance
+    spy_notifier_instance.success.assert_not_called()
+
+    # Not desired behaviour
+    spy_notifier_instance.failure.assert_not_called()
+
+    mock_upload_service.upload_new.assert_not_called()
+
+    # File should still be in processing
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    head_object_result = mock_s3_client.actual_client.head_object(
+        Bucket=uploaded_file_info.bucket_name,
+        Key=uploaded_file_info.initial_key_without_bucket,
+    )
+
+    assert "Error" not in head_object_result
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+
+    uploaded_file_info.verify_files_in_destination(
+        mock_s3_client.actual_client, expected_files, "processing/", 5
+    )
+
+    # Not desired behaviour
+    assert_no_emails_sent()

--- a/tests/integration/test_aws_secretsmanager_errors.py
+++ b/tests/integration/test_aws_secretsmanager_errors.py
@@ -1,0 +1,73 @@
+from unittest.mock import MagicMock, patch
+import boto3
+from moto import mock_aws
+import pytest
+from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
+from tests.integration.helpers.ses_assertion_helpers import assert_no_emails_sent
+from botocore.exceptions import ClientError
+
+actual_boto_client = boto3.client
+
+
+@patch("boto3.client")
+@mock_aws
+def test_secretsmanager_error(
+    mock_boto,
+    zip_file_object_key_factory,
+    s3_mock,
+    setup_secrets,
+    secretsmanager_mock,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """
+    Tests when S3 download object fails
+    """
+    zip_file_object_key = zip_file_object_key_factory()
+
+    error_response = {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}
+
+    def raise_exception(*args, **kwargs):
+        raise ClientError(error_response, "GetSecretValue")
+
+    secrets_manager_mock = MagicMock()
+    secrets_manager_mock.get_secret_value.side_effect = raise_exception
+
+    def get_moto_client_mock(*args, **kwargs):
+        if args[0] == "secretsmanager":
+            return secrets_manager_mock
+        return boto3.client(*args, **kwargs)
+
+    mock_boto.side_effect = get_moto_client_mock
+
+    from dpypelines.s3_folder_received import start
+
+    # Not desired behviour - should raise custom exception
+    with pytest.raises(Exception) as e:
+        start(zip_file_object_key)
+
+    assert "Failed to retrieve secrets from AWS Secrets Manager" in str(e.value)
+
+    assert len(mock_api_service_in_utils.instances) == 0
+
+    # Is this what it should be?
+    spy_notifier.assert_called()
+    assert len(spy_notifier.instances) == 0
+
+    mock_upload_service.upload_new.assert_not_called()
+
+    # File should still be in processing
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    head_object_result = mock_boto.head_object(
+        Bucket=uploaded_file_info.bucket_name,
+        Key=uploaded_file_info.initial_key_without_bucket,
+    )
+
+    assert "Error" not in head_object_result
+
+    # Not desired behaviour
+    assert_no_emails_sent()

--- a/tests/integration/test_aws_ses_errors.py
+++ b/tests/integration/test_aws_ses_errors.py
@@ -1,0 +1,92 @@
+from unittest.mock import MagicMock, patch
+import boto3
+from moto import mock_aws
+import pytest
+from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
+from tests.integration.helpers.ses_assertion_helpers import assert_no_emails_sent
+from tests.integration.helpers.upload_service_assertion_helpers import (
+    validate_successful_upload_service_calls,
+)
+from botocore.exceptions import ClientError
+
+actual_boto_client = boto3.client
+
+
+@patch("boto3.client")
+@mock_aws
+def test_ses_sendemail_error(
+    mock_boto,
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """
+    Test when an error is thrown by AWS SES client
+    """
+
+    error_response = {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}
+
+    def raise_exception(*args, **kwargs):
+        raise ClientError(error_response, "SendEmail")
+
+    ses_mock = MagicMock()
+    ses_mock.send_email.side_effect = raise_exception
+
+    def get_moto_client_mock(*args, **kwargs):
+        if args[0] == "ses":
+            return ses_mock
+        return actual_boto_client(*args, **kwargs)
+
+    mock_boto.side_effect = get_moto_client_mock
+    zip_file_object_key = zip_file_object_key_factory()
+
+    from dpypelines.s3_folder_received import start
+
+    with pytest.raises(ClientError) as e:
+        start(zip_file_object_key)
+
+    assert e.value.operation_name == "SendEmail"
+
+    assert len(mock_api_service_in_utils.instances) == 1
+
+    mock_api_client_instance = mock_api_service_in_utils.instances[0]
+    mock_api_client_instance.get.assert_called_once()
+    mock_api_client_instance.get_path.assert_called_once()
+    mock_api_client_instance.post_json.assert_called_once()
+
+    assert len(spy_notifier.call_args_list) == 1
+    spy_notifier_instance = spy_notifier.instances[0]
+    spy_notifier_instance.success.assert_not_called()
+    spy_notifier_instance.failure.assert_called_once()
+
+    mock_upload_service.upload_new.assert_called()
+
+    validate_successful_upload_service_calls(mock_upload_service)
+
+    # Verify S3 operations - check if processing folder exists
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processed/", 8
+    )
+
+    # Undesired behaviour
+    # Copies files -> goes to send email -> errors before deleting
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/", 8
+    )
+
+    assert_no_emails_sent()

--- a/tests/integration/test_data_file_errors.py
+++ b/tests/integration/test_data_file_errors.py
@@ -1,0 +1,140 @@
+import json
+import boto3
+import pytest
+from moto import mock_aws
+
+from tests.integration.helpers.file_helpers import (
+    DATA_FILE_NAME,
+    FileGenerationConfig,
+)
+from tests.integration.helpers.notification_assertion_helpers import (
+    assert_no_success_and_one_failure,
+    assert_success_notification,
+)
+from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
+from tests.integration.helpers.ses_assertion_helpers import (
+    assert_exception_email_sent,
+    assert_successful_email,
+)
+
+
+@mock_aws
+def test_missing_data(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """Test a successful pipeline execution with mocked AWS services."""
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory(
+        data_config=FileGenerationConfig(include=False)
+    )
+
+    with pytest.raises(Exception) as e:
+        start(zip_file_object_key)
+
+    assert DATA_FILE_NAME in str(e)
+
+    assert_no_success_and_one_failure(spy_notifier)
+
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = ["metadata.json", "manifest.json", uploaded_file_info.file_name]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/"
+    )
+
+    # Not desired behaviour
+    assert_exception_email_sent(str(e.value))
+
+
+@mock_aws
+def test_empty_data(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """Test a successful pipeline execution with mocked AWS services."""
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory(
+        data_config=FileGenerationConfig(include=True, empty=True)
+    )
+
+    with pytest.raises(Exception) as e:
+        start(zip_file_object_key)
+
+    assert_no_success_and_one_failure(spy_notifier)
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/"
+    )
+    # Not desired behaviour
+    assert_exception_email_sent(str(e.value))
+
+
+@mock_aws
+def test_unsupported_filetype(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """Test a successful pipeline execution with mocked AWS services."""
+    data_contents = {
+        "somekey": "somevalue"
+    }
+    data_file_name = "data.json"
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory(
+        data_config=FileGenerationConfig(include=True, content=json.dumps(data_contents)),
+        data_file_name=data_file_name
+    )
+
+    # The following assertions are likely incorrect, but match current implementation
+    result = start(zip_file_object_key)
+    assert result
+    assert_success_notification(spy_notifier)
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        data_file_name,
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processed/"
+    )
+    
+    # Not desired behaviour
+    assert_successful_email()

--- a/tests/integration/test_dataset_api_errors.py
+++ b/tests/integration/test_dataset_api_errors.py
@@ -1,0 +1,183 @@
+import boto3
+import pytest
+from moto import mock_aws
+from tests.integration.helpers.notification_assertion_helpers import (
+    assert_no_success_and_one_failure,
+)
+from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
+from tests.integration.helpers.ses_assertion_helpers import (
+    assert_exception_email_sent,
+    assert_no_emails_sent,
+)
+
+
+@mock_aws
+def test_non_static_dataset(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """
+    Test dataset type that isn't static
+    """
+    # Run the pipeline with the S3 object name
+    mock_api_service_in_utils.mock_config.mock_get_response.text = (
+        '{"current": {"type": "not-static"}}'
+    )
+
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory()
+    result = start(zip_file_object_key)
+
+    # Assertions
+    assert result is False
+
+    assert len(spy_notifier.instances) == 1
+    spy_notifier_instance = spy_notifier.instances[0]
+    spy_notifier_instance.success.assert_not_called()
+    spy_notifier_instance.failure.assert_not_called()
+
+    assert len(mock_api_service_in_utils.instances) == 1
+
+    mock_api_client_instance = mock_api_service_in_utils.instances[0]
+    mock_api_client_instance.get_path.assert_called_once()
+    mock_api_client_instance.get.assert_called_once()
+
+    mock_api_client_instance.post_json.assert_not_called()
+
+    mock_upload_service.upload_new.assert_not_called()
+
+    # Verify S3 operations - check if processing folder exists
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "dataset-type-not-static/"
+    )
+
+    # Not desired behaviour
+    assert_no_emails_sent()
+
+
+@mock_aws
+def test_get_path_404_error(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """
+    Test 404 error retrieving dataset version from Dataset API
+    """
+    # Run the pipeline with the S3 object name
+    mock_api_service_in_utils.mock_config.mock_get_path_response.text = None
+    mock_api_service_in_utils.mock_config.mock_get_path_response.status_code = 404
+
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory()
+    with pytest.raises(Exception) as e:
+        start(zip_file_object_key)
+
+    assert_no_success_and_one_failure(spy_notifier)
+
+    assert len(mock_api_service_in_utils.instances) == 1
+
+    mock_api_client_instance = mock_api_service_in_utils.instances[0]
+    mock_api_client_instance.get_path.assert_called_once()
+    mock_api_client_instance.get.assert_not_called()
+    mock_api_client_instance.post_json.assert_not_called()
+
+    mock_upload_service.upload_new.assert_not_called()
+
+    # Verify S3 operations - check if processing folder exists
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/"
+    )
+
+    # Not desired behaviour
+    assert_exception_email_sent(str(e.value))
+
+
+@mock_aws
+def test_post_json_error(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """
+    Test when dataset API has a non-success response when uploading the metadata
+    """
+    # Run the pipeline with the S3 object name
+    mock_api_service_in_utils.mock_config.mock_post_json_response.text = None
+    mock_api_service_in_utils.mock_config.mock_post_json_response.status_code = 500
+
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory()
+
+    with pytest.raises(Exception) as e:
+        start(zip_file_object_key)
+
+    assert "Mock error raised as mock" in str(e.value)
+
+    assert_no_success_and_one_failure(spy_notifier)
+
+    assert len(mock_api_service_in_utils.instances) == 1
+
+    mock_api_client_instance = mock_api_service_in_utils.instances[0]
+    mock_api_client_instance.get.assert_called_once()
+    mock_api_client_instance.get_path.assert_called_once()
+    mock_api_client_instance.post_json.assert_called_once()
+
+    mock_upload_service.upload_new.assert_not_called()
+
+    # Verify S3 operations - check if processing folder exists
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    # Not right behaviour - should be in errored
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/"
+    )
+    # Not desired behaviour
+    assert_exception_email_sent(str(e.value))

--- a/tests/integration/test_feature_flags.py
+++ b/tests/integration/test_feature_flags.py
@@ -1,0 +1,183 @@
+import boto3
+from moto import mock_aws
+from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
+from tests.integration.helpers.ses_assertion_helpers import (
+    assert_no_emails_sent,
+    assert_successful_email,
+)
+from tests.integration.helpers.upload_service_assertion_helpers import (
+    validate_successful_upload_service_calls,
+)
+
+
+@mock_aws
+def test_notifications_disabled(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+    monkeypatch,
+):
+    """
+    Test notifications are not sent if disabled
+    """
+    monkeypatch.setenv("DISABLE_NOTIFICATIONS", "True")
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory()
+    result = start(zip_file_object_key)
+
+    # Assertions
+    assert result is True
+
+    assert len(mock_api_service_in_utils.instances) == 1
+
+    mock_api_client_instance = mock_api_service_in_utils.instances[0]
+    mock_api_client_instance.get.assert_called_once()
+    mock_api_client_instance.get_path.assert_called_once()
+    mock_api_client_instance.post_json.assert_called_once()
+
+    spy_notifier.assert_not_called()
+    spy_notifier_instance = spy_notifier.instance
+    spy_notifier_instance.success.assert_not_called()
+    spy_notifier_instance.failure.assert_not_called()
+
+    mock_upload_service.upload_new.assert_called()
+
+    validate_successful_upload_service_calls(mock_upload_service)
+
+    # Verify S3 operations - check if processing folder exists
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processed/"
+    )
+    monkeypatch.setenv("DISABLE_NOTIFICATIONS", "False")
+    assert_successful_email()
+
+
+@mock_aws
+def test_emails_disabled(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+    monkeypatch,
+):
+    """
+    Tests emails are not sent if disabled
+    """
+    monkeypatch.setenv("DISABLE_EMAILS", "True")
+
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory()
+    result = start(zip_file_object_key)
+
+    # Assertions
+    assert result is True
+
+    assert len(mock_api_service_in_utils.instances) == 1
+
+    mock_api_client_instance = mock_api_service_in_utils.instances[0]
+    mock_api_client_instance.get.assert_called_once()
+    mock_api_client_instance.get_path.assert_called_once()
+    mock_api_client_instance.post_json.assert_called_once()
+
+    spy_notifier.assert_called_once()
+    spy_notifier_instance = spy_notifier.instances[0]
+    spy_notifier_instance.success.assert_called_once()
+    spy_notifier_instance.failure.assert_not_called()
+
+    mock_upload_service.upload_new.assert_called()
+
+    validate_successful_upload_service_calls(mock_upload_service)
+
+    # Verify S3 operations - check if processing folder exists
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processed/"
+    )
+
+    assert_no_emails_sent()
+    monkeypatch.setenv("DISABLE_EMAILS", "False")
+
+
+# Test upload disabled
+@mock_aws
+def test_file_upload_disabled(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+    monkeypatch,
+):
+    """
+    Tests uploads do not happen if disabled
+    """
+    monkeypatch.setenv("SKIP_DATA_UPLOAD", "True")
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory()
+    result = start(zip_file_object_key)
+
+    # Assertions
+    assert result is None
+
+    assert len(mock_api_service_in_utils.instances) == 0
+
+    spy_notifier.assert_called_once()
+    spy_notifier_instance = spy_notifier.instance
+    spy_notifier_instance.success.assert_not_called()
+    spy_notifier_instance.failure.assert_not_called()
+
+    mock_upload_service.upload_new.assert_not_called()
+
+    # Verify S3 operations - check if processing folder exists
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+
+    # Is this desired behaviour?
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/"
+    )
+
+    assert_no_emails_sent()
+    monkeypatch.setenv("DISABLE_EMAILS", "False")

--- a/tests/integration/test_job_configuration_errors.py
+++ b/tests/integration/test_job_configuration_errors.py
@@ -1,0 +1,106 @@
+import json
+import sys
+from moto import mock_aws
+import pytest
+
+from tests.integration.helpers.ses_assertion_helpers import assert_no_emails_sent
+
+
+# Environment variables
+@mock_aws
+def test_invalid_environment_variables(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+    monkeypatch,
+    reset_pipelines_module,
+):
+    """
+    Test environment variables are a non-boolean string but should be boolean
+    """
+    monkeypatch.setenv("DISABLE_NOTIFICATIONS", "not-a-bool")
+
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory()
+
+    with pytest.raises(ValueError) as e:
+        start(zip_file_object_key)
+
+    assert "A str value representing a boolean" in str(e)
+    monkeypatch.setenv("DISABLE_NOTIFICATIONS", "False")
+    # Not desired behaviour
+    assert_no_emails_sent()
+
+
+# Secrets
+@mock_aws
+def test_missing_secret(
+    zip_file_object_key_factory,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+    reset_pipelines_module,
+):
+    """
+    Test secret not found in AWS Secrets Manager
+    """
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory()
+
+    with pytest.raises(Exception) as e:
+        start(zip_file_object_key)
+
+    assert "Failed to retrieve secrets from AWS Secrets Manager" in str(e)
+    # Not desired behaviour
+    assert_no_emails_sent()
+
+
+@mock_aws
+def test_missing_secret_keys(
+    zip_file_object_key_factory,
+    secretsmanager_mock,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+    reset_pipelines_module,
+):
+    """
+    Secret exists in AWS Secrets Manager, but is missing a key value
+    """
+    secret_value = {
+        "DATASET_API_URL": "http://test-dataset-api.url",
+        "UPLOAD_SERVICE_URL": "http://test-upload-service.url",
+    }
+
+    secretsmanager_mock.create_secret(
+        Name="dp-test-secrets", SecretString=json.dumps(secret_value)
+    )
+
+    for key in list(sys.modules.keys()):
+        if key.startswith("JobConfiguration") or key.endswith("JobConfiguration"):
+            del sys.modules[key]
+
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory()
+
+    with pytest.raises(AttributeError) as e:
+        start(zip_file_object_key)
+
+    assert "Secret key '" in str(e)
+    assert "missing" in str(e)
+    # Not desired behaviour
+    assert_no_emails_sent()

--- a/tests/integration/test_manifest_file_errors.py
+++ b/tests/integration/test_manifest_file_errors.py
@@ -1,0 +1,193 @@
+from json import JSONDecodeError
+import boto3
+import pytest
+from moto import mock_aws
+
+from tests.integration.helpers.file_helpers import (
+    FileGenerationConfig,
+)
+from tests.integration.helpers.notification_assertion_helpers import (
+    assert_no_success_and_one_failure,
+)
+from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
+from tests.integration.helpers.ses_assertion_helpers import assert_no_emails_sent
+
+
+@mock_aws
+def test_missing_manifest(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """
+    Manifest file missing from zip file
+    """
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory(
+        manifest_config=FileGenerationConfig(include=False)
+    )
+
+    with pytest.raises(FileNotFoundError) as e:
+        start(zip_file_object_key)
+
+    assert "Failed to retrieve manifest from the local directory store" in str(e.value)
+    assert_no_success_and_one_failure(spy_notifier)
+
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = ["data.csv", "metadata.json", uploaded_file_info.file_name]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/"
+    )
+
+    # Not desired behaviour
+    assert_no_emails_sent()
+
+
+@mock_aws
+def test_empty_manifest(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """
+    Manifst file empty.
+    """
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory(
+        manifest_config=FileGenerationConfig(include=True, empty=True)
+    )
+
+    # This is the wrong expected behaviour, but it's what's actually happening currently.
+    with pytest.raises(JSONDecodeError):
+        start(zip_file_object_key)
+
+    assert_no_success_and_one_failure(spy_notifier)
+
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/"
+    )
+    # Not desired behaviour
+    assert_no_emails_sent()
+
+
+required_manifest_fields = [
+    "metadata_file",
+    "submission_contacts",
+]
+
+
+@pytest.mark.parametrize("field_to_remove", required_manifest_fields)
+@mock_aws
+def test_manifest_missing_fields(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+    field_to_remove,
+):
+    """
+    Manifest file missing fields.
+    """
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory(
+        manifest_config=FileGenerationConfig(
+            include=True, missing_field_keys=[field_to_remove]
+        )
+    )
+
+    # This is the wrong expected behaviour, but it's what's actually happening currently.
+    with pytest.raises(Exception) as e:
+        start(zip_file_object_key)
+
+    assert field_to_remove in str(e.value)
+    assert_no_success_and_one_failure(spy_notifier)
+
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/"
+    )
+    # Not desired behaviour
+    assert_no_emails_sent()
+
+
+@mock_aws
+def test_manifest_fails_when_invalid_json(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """Test failure when manifest file is not a valid JSON."""
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory(
+        manifest_config=FileGenerationConfig(include=True, content="this is not json")
+    )
+
+    # Differs to metadata as metadata loads it using dpypelines/pipeline/validate_pipeline.read_json_file method
+    # But the manifest uses the implementation in LocalDirectoryStore
+    # Implementations should be amended to match
+    with pytest.raises(JSONDecodeError):
+        start(zip_file_object_key)
+
+    assert_no_success_and_one_failure(spy_notifier)
+
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/"
+    )
+
+    # Not desired behaviour - shouldn't send exception email to data publisher.
+    assert_no_emails_sent()

--- a/tests/integration/test_metadata_file_errors.py
+++ b/tests/integration/test_metadata_file_errors.py
@@ -1,0 +1,240 @@
+import boto3
+from pydantic import ValidationError
+import pytest
+from moto import mock_aws
+
+from tests.integration.helpers.file_helpers import (
+    METADATA_FILE_NAME,
+    FileGenerationConfig,
+)
+from tests.integration.helpers.notification_assertion_helpers import (
+    assert_no_success_and_one_failure,
+)
+from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
+from tests.integration.helpers.ses_assertion_helpers import (
+    assert_exception_email_sent,
+    assert_successful_email,
+)
+
+
+@mock_aws
+def test_missing_metadata(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """Test pipeline handles missing metadata file"""
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory(
+        metadata_config=FileGenerationConfig(include=False)
+    )
+
+    with pytest.raises(Exception) as e:
+        start(zip_file_object_key)
+
+    assert METADATA_FILE_NAME in str(e)
+    assert_no_success_and_one_failure(spy_notifier)
+
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = ["data.csv", "manifest.json", uploaded_file_info.file_name]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/"
+    )
+
+
+@mock_aws
+def test_empty_metadata(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """Test pipeline handles an empty metadata file."""
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory(
+        metadata_config=FileGenerationConfig(include=True, empty=True)
+    )
+
+    with pytest.raises(ValueError) as e:
+        start(zip_file_object_key)
+
+    assert "File is empty" in str(e)
+    assert METADATA_FILE_NAME in str(e)
+    assert_no_success_and_one_failure(spy_notifier)
+
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/"
+    )
+
+    # Not desired behaviour
+    assert_exception_email_sent(str(e.value))
+
+
+required_metadata_fields = ["dataset_id", "edition_title", "release_date", "edition"]
+
+
+@pytest.mark.parametrize("field_to_remove", required_metadata_fields)
+@mock_aws
+def test_metadata_fails_when_missing_required_field(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+    field_to_remove,
+):
+    """Test a pipeline handles errors when metadata is missing required fields"""
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory(
+        metadata_config=FileGenerationConfig(
+            include=True, missing_field_keys=[field_to_remove]
+        )
+    )
+
+    with pytest.raises(ValidationError) as e:
+        start(zip_file_object_key)
+
+    assert field_to_remove in str(e.value)
+    assert_no_success_and_one_failure(spy_notifier)
+
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/"
+    )
+
+    # Not desired behaviour
+    assert_exception_email_sent(str(e.value))
+
+
+metadata_optional_fields = [
+    "distributions",
+    "quality_designation",
+    "usage_notes",
+    "alerts",
+]
+
+
+@pytest.mark.parametrize("field_to_remove", metadata_optional_fields)
+@mock_aws
+def test_metadata_succeeds_when_missing_optional_field(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+    field_to_remove,
+):
+    """Test pipeline still works when metadata is missing optional fields"""
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory(
+        metadata_config=FileGenerationConfig(
+            include=True, missing_field_keys=[field_to_remove]
+        )
+    )
+
+    result = start(zip_file_object_key)
+    assert result
+
+    assert len(spy_notifier.instances) == 1
+    spy_notifier.instances[0].success.assert_called_once()
+
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processed/"
+    )
+
+    assert_successful_email()
+
+
+@mock_aws
+def test_metadata_fails_when_invalid_json(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """Test a successful pipeline execution with mocked AWS services."""
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory(
+        metadata_config=FileGenerationConfig(include=True, content="this is not json")
+    )
+
+    with pytest.raises(ValueError) as e:
+        start(zip_file_object_key)
+
+    assert "not valid JSON" in str(e.value), str(e.value)
+    assert "metadata.json" in str(e.value), str(e.value)
+
+    assert_no_success_and_one_failure(spy_notifier)
+
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/"
+    )
+
+    # Couldn't read metadata so no submitter info to notify
+    assert_exception_email_sent(str(e.value))

--- a/tests/integration/test_notification_errors.py
+++ b/tests/integration/test_notification_errors.py
@@ -1,0 +1,78 @@
+import boto3
+from moto import mock_aws
+import pytest
+from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
+from tests.integration.helpers.ses_assertion_helpers import (
+    get_sent_emails,
+)
+from tests.integration.helpers.upload_service_assertion_helpers import (
+    validate_successful_upload_service_calls,
+)
+
+
+@mock_aws
+def test_slack_notification_error(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """
+    Tests when a Slack notification fails
+    """
+
+    def throw_error(error_message: str):
+        raise Exception(error_message)
+
+    mock_slack.msg_str.side_effect = throw_error
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory()
+
+    with pytest.raises(Exception):
+        start(zip_file_object_key)
+
+    assert len(mock_api_service_in_utils.instances) == 1
+
+    mock_api_client_instance = mock_api_service_in_utils.instances[0]
+    mock_api_client_instance.get.assert_called_once()
+    mock_api_client_instance.get_path.assert_called_once()
+    mock_api_client_instance.post_json.assert_called_once()
+
+    assert len(spy_notifier.call_args_list) == 1
+    spy_notifier_instance = spy_notifier.instances[0]
+    spy_notifier_instance.success.assert_called_once()
+    spy_notifier_instance.failure.assert_called_once()
+
+    mock_upload_service.upload_new.assert_called()
+
+    validate_successful_upload_service_calls(mock_upload_service)
+
+    # Verify S3 operations - check if processing folder exists
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+
+    # Not desired behaviour
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processed/", 8
+    )
+
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/", 8
+    )
+
+    # Not desired behaviour
+    sent_emails = get_sent_emails()
+    assert len(sent_emails) == 2

--- a/tests/integration/test_s3_folder_received_success.py
+++ b/tests/integration/test_s3_folder_received_success.py
@@ -1,0 +1,75 @@
+import boto3
+from moto import mock_aws
+import pytest
+from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
+from tests.integration.helpers.ses_assertion_helpers import (
+    assert_successful_email,
+)
+from tests.integration.helpers.upload_service_assertion_helpers import (
+    validate_successful_upload_service_calls,
+)
+
+files_to_generate = ["csvfile.csv", "sqlite.csdb", "excel.xls", "otherexcel.xlsx"]
+
+
+@pytest.mark.parametrize("data_file_name", files_to_generate)
+@mock_aws
+def test_successful_pipeline_execution(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+    data_file_name,
+):
+    """
+    Test a successful pipeline execution with mocked services.
+    """
+
+    zip_file_object_key = zip_file_object_key_factory(data_file_name=data_file_name)
+
+    from dpypelines.s3_folder_received import start
+
+    result = start(zip_file_object_key)
+
+    # Assertions
+    assert result is True
+
+    assert len(mock_api_service_in_utils.instances) == 1
+
+    mock_api_client_instance = mock_api_service_in_utils.instances[0]
+    mock_api_client_instance.get.assert_called_once()
+    mock_api_client_instance.get_path.assert_called_once()
+    mock_api_client_instance.post_json.assert_called_once()
+
+    spy_notifier.assert_called_once()
+    spy_notifier_instance = spy_notifier.instances[0]
+    spy_notifier_instance.success.assert_called_once()
+    spy_notifier_instance.failure.assert_not_called()
+
+    mock_upload_service.upload_new.assert_called()
+
+    validate_successful_upload_service_calls(
+        mock_upload_service, data_file_name=data_file_name
+    )
+
+    # Verify S3 operations - check if processing folder exists
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        data_file_name,
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processed/"
+    )
+
+    assert_successful_email()

--- a/tests/integration/test_upload_service_errors.py
+++ b/tests/integration/test_upload_service_errors.py
@@ -1,0 +1,136 @@
+from unittest.mock import MagicMock
+import boto3
+import pytest
+from moto import mock_aws
+from requests.exceptions import RequestException
+from tests.integration.helpers.notification_assertion_helpers import (
+    assert_no_success_and_one_failure,
+)
+from tests.integration.helpers.s3_assertion_helpers import (
+    S3ObjectFile,
+)
+from tests.integration.helpers.ses_assertion_helpers import (
+    assert_exception_email_sent,
+    assert_successful_email,
+)
+from tests.integration.helpers.upload_service_assertion_helpers import (
+    validate_successful_upload_service_calls,
+)
+
+
+@mock_aws
+def test_upload_service_request_exception(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """
+    Test dataset type that isn't static
+    """
+
+    def throw_error(required_file_path, mimetype):
+        raise RequestException()
+
+    mock_upload_service.upload_new.side_effect = throw_error
+
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory()
+
+    with pytest.raises(RequestException) as e:
+        start(zip_file_object_key)
+
+    assert_no_success_and_one_failure(spy_notifier)
+
+    assert len(mock_api_service_in_utils.instances) == 1
+
+    mock_api_client_instance = mock_api_service_in_utils.instances[0]
+    mock_api_client_instance.get.assert_called_once()
+    mock_api_client_instance.get_path.assert_called_once()
+    mock_api_client_instance.post_json.assert_called_once()
+
+    mock_upload_service.upload_new.assert_called_once()
+
+    # Verify S3 operations - check if processing folder exists
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    # Not expected behaviour - shouldn't have moved due to error
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processing/"
+    )
+
+    # Not desired behaviour
+    assert_exception_email_sent(str(e.value))
+
+
+@mock_aws
+def test_upload_service_returns_error(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_api_service_in_utils,
+    mock_upload_service,
+    spy_notifier,
+):
+    """
+    Test dataset type that isn't static
+    """
+    response_mock = MagicMock()
+    response_mock.status_code = 500
+    response_mock.text = "Some failure message here"
+    mock_upload_service.upload_new.return_value = response_mock
+
+    from dpypelines.s3_folder_received import start
+
+    zip_file_object_key = zip_file_object_key_factory()
+
+    result = start(zip_file_object_key)
+
+    # Not desired behaviour but is current behaviour
+    assert result
+
+    spy_notifier.instances[0].success.assert_called_once()
+    spy_notifier.instances[0].failure.assert_not_called()
+    # END not desired behaviour
+
+    assert len(mock_api_service_in_utils.instances) == 1
+
+    mock_api_client_instance = mock_api_service_in_utils.instances[0]
+    mock_api_client_instance.get.assert_called_once()
+    mock_api_client_instance.get_path.assert_called_once()
+    mock_api_client_instance.post_json.assert_called_once()
+
+    validate_successful_upload_service_calls(mock_upload_service)
+    # Verify S3 operations - check if processing folder exists
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+
+    expected_files = [
+        "data.csv",
+        "metadata.json",
+        "manifest.json",
+        uploaded_file_info.file_name,
+    ]
+    # Not expected behaviour - shouldn't have moved due to error
+    uploaded_file_info.verify_files_in_destination(
+        s3_client, expected_files, "processed/"
+    )
+
+    # Not desired behaviour
+    assert_successful_email()

--- a/tests/pipelines/pipeline/shared/validation/base_test_file_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/base_test_file_validator.py
@@ -44,19 +44,23 @@ class BaseTestFileValidator:
         self.validate_success(result)
 
     def _test_validator_errors_empty_file(self):
-        file_path = self._get_test_file_path()
-        file_path.touch()
+        file_path = self._generate_empty_file()
         validator = self.validator_type()
 
         result = validator.validate_file_format(file_path)
 
         self.validate_error(result)
 
+    def _generate_empty_file(self):
+        file_path = self._get_test_file_path()
+        file_path.touch()
+        return file_path
+
     def test_validator_errors_invalid_file(self):
         file_path = self._get_test_file_path()
 
         with open(file_path, "w") as f:
-            f.write("this should fail everything except text")
+            f.write('\x00\nt\n"dsaasd,"\n\theader1#header2#header3\nvalue1#value2#value3')
 
         validator = self.validator_type()
 

--- a/tests/pipelines/pipeline/shared/validation/base_test_file_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/base_test_file_validator.py
@@ -52,6 +52,18 @@ class BaseTestFileValidator:
 
         self.validate_error(result)
 
+    def test_validator_errors_invalid_file(self):
+        file_path = self._get_test_file_path()
+
+        with open(file_path, "w") as f:
+            f.write("this should fail everything except text")
+
+        validator = self.validator_type()
+
+        result = validator.validate_file_format(file_path)
+
+        self.validate_error(result)
+
     def validate_error(self, result: ValidationResult, error: Optional[str] = None):
         assert not result.valid
         assert result.error is not None if error is None else error

--- a/tests/pipelines/pipeline/shared/validation/base_test_file_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/base_test_file_validator.py
@@ -60,7 +60,9 @@ class BaseTestFileValidator:
         file_path = self._get_test_file_path()
 
         with open(file_path, "w") as f:
-            f.write('\x00\nt\n"dsaasd,"\n\theader1#header2#header3\nvalue1#value2#value3')
+            f.write(
+                '\x00\nt\n"dsaasd,"\n\theader1#header2#header3\nvalue1#value2#value3'
+            )
 
         validator = self.validator_type()
 

--- a/tests/pipelines/pipeline/shared/validation/test_csv_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/test_csv_validator.py
@@ -1,20 +1,50 @@
 import csv
+from io import StringIO
 from pathlib import Path
+
+import pytest
 from dpypelines.pipeline.validation.csv_validator import CSVValidator
 from tests.pipelines.pipeline.shared.validation.base_test_file_validator import (
     BaseTestFileValidator,
 )
 
+test_data = {
+    "headers": ["header1", "header2", "header3"],
+    "rows": [["value1", "value2", "value3"]]
+}
 
 class TestCSVValidator(BaseTestFileValidator):
     file_format: str = "csv"
     validator_type = CSVValidator
-
+    
+    def create_csv(self, delimiter: str) -> StringIO:
+        headers = delimiter.join(test_data["headers"])
+        rows = "\n".join(delimiter.join(row) for row in test_data["rows"])
+        
+        return headers + "\n" + rows
+    
+    @pytest.fixture
+    def valid_csv_file(self):
+        return StringIO(self.create_csv(","))
+    
+    @pytest.fixture
+    def valid_tsv_file(self):
+        return StringIO(self.create_csv("\n"))
+    
+    @pytest.fixture
+    def valid_semicolon_file(self):
+        return StringIO(self.create_csv(";"))
+    
+    @pytest.fixture
+    def invalid_file(self):
+        return StringIO("{this is some other file}")
+    
     def generate_test_file(self, file_path: Path):
         with open(file_path, "w", newline="") as csvfile:
             writer = csv.writer(csvfile)
-            writer.writerow(["id", "name", "value"])
-
+            writer.writerow(test_data["headers"])
+            writer.writerows(test_data["rows"])
+            
     def test_validator_passes_valid_file(self):
         """Test that CSV files are validated with the CSV validator."""
         self._test_validator_passes_valid_file()
@@ -23,3 +53,32 @@ class TestCSVValidator(BaseTestFileValidator):
     def test_validator_errors_empty_file(self):
         """Test that CSV files are validated with the CSV validator."""
         self._test_validator_errors_empty_file()
+
+    def test_sniffer_valid_csv(self):
+        file = StringIO(self.create_csv(","))
+        validator = CSVValidator()
+        
+        result = validator._try_validate_with_sniffer(file)
+        
+        assert result is True
+    
+    def test_sniffer_valid_tsv(self):
+        file = StringIO(self.create_csv("\n"))
+        validator = CSVValidator()
+
+        result = validator._try_validate_with_sniffer(file)
+        assert result is True
+    
+    def test_sniffer_valid_semicolon(self):
+        file = StringIO(self.create_csv(";"))
+        validator = CSVValidator()
+        
+        result = validator._try_validate_with_sniffer(file)
+        
+        assert result is True
+    
+    def test_sniffer_invalid_csv(self, invalid_file):
+        validator = CSVValidator()
+
+        result = validator._try_validate_with_sniffer(invalid_file)
+        assert isinstance(result, bool) 

--- a/tests/pipelines/pipeline/shared/validation/test_csv_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/test_csv_validator.py
@@ -1,50 +1,48 @@
-import csv
 from io import StringIO
 from pathlib import Path
 
 import pytest
 from dpypelines.pipeline.validation.csv_validator import CSVValidator
+from tests.helpers.generators.data_file_generators import generate_csv
 from tests.pipelines.pipeline.shared.validation.base_test_file_validator import (
     BaseTestFileValidator,
 )
 
 test_data = {
     "headers": ["header1", "header2", "header3"],
-    "rows": [["value1", "value2", "value3"]]
+    "rows": [["value1", "value2", "value3"]],
 }
+
 
 class TestCSVValidator(BaseTestFileValidator):
     file_format: str = "csv"
     validator_type = CSVValidator
-    
+
     def create_csv(self, delimiter: str) -> StringIO:
         headers = delimiter.join(test_data["headers"])
         rows = "\n".join(delimiter.join(row) for row in test_data["rows"])
-        
+
         return headers + "\n" + rows
-    
+
     @pytest.fixture
     def valid_csv_file(self):
         return StringIO(self.create_csv(","))
-    
+
     @pytest.fixture
     def valid_tsv_file(self):
         return StringIO(self.create_csv("\n"))
-    
+
     @pytest.fixture
     def valid_semicolon_file(self):
         return StringIO(self.create_csv(";"))
-    
+
     @pytest.fixture
     def invalid_file(self):
         return StringIO("{this is some other file}")
-    
+
     def generate_test_file(self, file_path: Path):
-        with open(file_path, "w", newline="") as csvfile:
-            writer = csv.writer(csvfile)
-            writer.writerow(test_data["headers"])
-            writer.writerows(test_data["rows"])
-            
+        generate_csv(file_path, [test_data["headers"], *test_data["rows"]])
+
     def test_validator_passes_valid_file(self):
         """Test that CSV files are validated with the CSV validator."""
         self._test_validator_passes_valid_file()
@@ -57,28 +55,28 @@ class TestCSVValidator(BaseTestFileValidator):
     def test_sniffer_valid_csv(self):
         file = StringIO(self.create_csv(","))
         validator = CSVValidator()
-        
+
         result = validator._try_validate_with_sniffer(file)
-        
+
         assert result is True
-    
+
     def test_sniffer_valid_tsv(self):
         file = StringIO(self.create_csv("\n"))
         validator = CSVValidator()
 
         result = validator._try_validate_with_sniffer(file)
         assert result is True
-    
+
     def test_sniffer_valid_semicolon(self):
         file = StringIO(self.create_csv(";"))
         validator = CSVValidator()
-        
+
         result = validator._try_validate_with_sniffer(file)
-        
+
         assert result is True
-    
+
     def test_sniffer_invalid_csv(self, invalid_file):
         validator = CSVValidator()
 
         result = validator._try_validate_with_sniffer(invalid_file)
-        assert isinstance(result, bool) 
+        assert isinstance(result, bool)

--- a/tests/pipelines/pipeline/shared/validation/test_excel_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/test_excel_validator.py
@@ -1,5 +1,5 @@
-import pandas as pd
 from dpypelines.pipeline.validation.excel_validator import ExcelValidator
+from tests.helpers.generators.data_file_generators import generate_excel
 from tests.pipelines.pipeline.shared.validation.base_test_file_validator import (
     BaseTestFileValidator,
 )
@@ -10,10 +10,7 @@ class BaseTestExcelValidator(BaseTestFileValidator):
     validator_type = ExcelValidator
 
     def generate_test_file(self, file_path: Path):
-        data = {"id": [1, 2], "name": ["item1", "item2"], "value": [42.5, 13.7]}
-        df = pd.DataFrame(data)
-
-        df.to_excel(file_path, index=False)
+        generate_excel(file_path)
 
 
 class TestXLSValidator(BaseTestExcelValidator):

--- a/tests/pipelines/pipeline/shared/validation/test_models.py
+++ b/tests/pipelines/pipeline/shared/validation/test_models.py
@@ -1,0 +1,25 @@
+import pytest
+from dpypelines.pipeline.validation.models import ValidationResult
+
+test_data = [
+    (True, "csv", None),
+    (True, "other-format", None),
+    (True, "excel", "Should't be an error here but doesn't matter"),
+    (False, "json", "Some error here"),
+    (False, "xls", "")
+]
+
+@pytest.mark.parametrize("success,format,error", test_data)
+def test_should_write_success_to_string(success: bool, format: str, error):
+    result = ValidationResult(success, format, error)
+    
+    result_string = result.__repr__()
+
+    assert "[ValidationResult]" in result_string, result_string
+    assert str(success) in result_string, result_string
+    assert str(not success) not in result_string, result_string
+    assert format in result_string, result_string
+    if error is None:
+        assert "error: None" in result_string
+    else:
+        assert f"'{error}'" in result_string, result_string

--- a/tests/pipelines/pipeline/shared/validation/test_models.py
+++ b/tests/pipelines/pipeline/shared/validation/test_models.py
@@ -6,13 +6,14 @@ test_data = [
     (True, "other-format", None),
     (True, "excel", "Should't be an error here but doesn't matter"),
     (False, "json", "Some error here"),
-    (False, "xls", "")
+    (False, "xls", ""),
 ]
+
 
 @pytest.mark.parametrize("success,format,error", test_data)
 def test_should_write_success_to_string(success: bool, format: str, error):
     result = ValidationResult(success, format, error)
-    
+
     result_string = result.__repr__()
 
     assert "[ValidationResult]" in result_string, result_string

--- a/tests/pipelines/pipeline/shared/validation/test_sqlite_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/test_sqlite_validator.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import sqlite3
+from dpypelines.pipeline.validation.sqlite_validator import SQLiteValidator
+from tests.pipelines.pipeline.shared.validation.base_test_file_validator import (
+    BaseTestFileValidator,
+)
+
+
+class TestSQLiteValidator(BaseTestFileValidator):
+    file_format: str = "csdb"
+    validator_type = SQLiteValidator
+
+    def generate_test_file(self, file_path: Path):
+        conn = sqlite3.connect(str(file_path))
+        cursor = conn.cursor()
+        cursor.execute("CREATE TABLE dummy_table(id)")
+        conn.close()
+
+    def test_validator_passes_valid_file(self):
+        """Test that sqlite files are validated with the sqlite validator."""
+        self._test_validator_passes_valid_file()
+        assert True
+
+    def test_validator_errors_empty_file(self):
+        """Test that sqlite files are validated with the sqlite validator."""
+        self._test_validator_errors_empty_file()

--- a/tests/pipelines/pipeline/shared/validation/test_sqlite_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/test_sqlite_validator.py
@@ -1,6 +1,6 @@
 from pathlib import Path
-import sqlite3
 from dpypelines.pipeline.validation.sqlite_validator import SQLiteValidator
+from tests.helpers.generators.data_file_generators import generate_csdb
 from tests.pipelines.pipeline.shared.validation.base_test_file_validator import (
     BaseTestFileValidator,
 )
@@ -11,10 +11,7 @@ class TestSQLiteValidator(BaseTestFileValidator):
     validator_type = SQLiteValidator
 
     def generate_test_file(self, file_path: Path):
-        conn = sqlite3.connect(str(file_path))
-        cursor = conn.cursor()
-        cursor.execute("CREATE TABLE dummy_table(id)")
-        conn.close()
+        generate_csdb(file_path)
 
     def test_validator_passes_valid_file(self):
         """Test that sqlite files are validated with the sqlite validator."""

--- a/tests/pipelines/pipeline/shared/validation/test_sqlite_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/test_sqlite_validator.py
@@ -24,3 +24,9 @@ class TestSQLiteValidator(BaseTestFileValidator):
     def test_validator_errors_empty_file(self):
         """Test that sqlite files are validated with the sqlite validator."""
         self._test_validator_errors_empty_file()
+
+    def test_handles_sqlite_error(self):
+        file_path = self._get_test_file_path()
+
+        with open(file_path, "w") as f:
+            f.write("this is not a sqlite file")

--- a/tests/pipelines/pipeline/shared/validation/test_text_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/test_text_validator.py
@@ -34,3 +34,6 @@ class TestXMLValidator(BaseTestFileValidator):
         result = validator.validate_file_format(file_path)
 
         self.validate_error(result)
+
+    def test_validator_errors_invalid_file(self):
+        pass

--- a/tests/pipelines/pipeline/shared/validation/test_xml_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/test_xml_validator.py
@@ -1,10 +1,9 @@
 from dpypelines.pipeline.validation.xml_validator import XMLValidator
+from tests.helpers.generators.data_file_generators import generate_xml
 from tests.pipelines.pipeline.shared.validation.base_test_file_validator import (
     BaseTestFileValidator,
 )
 from pathlib import Path
-import xml.etree.ElementTree as ET
-import xml.dom.minidom as minidom
 
 
 class TestXMLValidator(BaseTestFileValidator):
@@ -12,26 +11,7 @@ class TestXMLValidator(BaseTestFileValidator):
     validator_type = XMLValidator
 
     def generate_test_file(self, file_path: Path):
-        # Create root element
-        root = ET.Element("root")
-
-        # Add items
-        items = ET.SubElement(root, "items")
-
-        # Add item
-        item1 = ET.SubElement(items, "item")
-        item1.set("id", "1")
-        name1 = ET.SubElement(item1, "name")
-        name1.text = "item1"
-        value1 = ET.SubElement(item1, "value")
-        value1.text = "."
-
-        rough_string = ET.tostring(root, "utf-8")
-        reparsed = minidom.parseString(rough_string)
-        pretty_xml = reparsed.toprettyxml(indent="  ")
-
-        with open(file_path, "w") as xmlfile:
-            xmlfile.write(pretty_xml)
+        generate_xml(file_path)
 
     def test_validator_passes_valid_file(self):
         self._test_validator_passes_valid_file()

--- a/tests/pipelines/pipeline/test_job_configuration.py
+++ b/tests/pipelines/pipeline/test_job_configuration.py
@@ -5,13 +5,15 @@ import pytest
 
 import dpypelines.pipeline.config.job_configuration
 from dpypelines.pipeline.config import SecretConfig
-from dpypelines.pipeline.config.job_configuration import secrets_config
+from dpypelines.pipeline.config.job_configuration import get_default_secrets_config
+from dpypelines.pipeline.config.secret_mapping import SecretMapping
 
 secrets = {}
 
 expected_secret_name = "dp-sandbox-secrets"
 test_secret_one = SecretConfig("TEST_ONE", "test_attr_one")
 test_secret_two = SecretConfig("OTHER_TEST", "other_test_attr")
+secrets_config = get_default_secrets_config()
 test_secret_config = [*secrets_config, test_secret_one, test_secret_two]
 
 
@@ -54,10 +56,10 @@ def test_should_load_config(secrets_client):
     can be created taking a secrets client, environment variables config, and secrets config.
     The result should raisei no errors, with the contents matching the expected results.
     """
-    secrets_client.return_value.get_secret.side_effect = get_secret
-
     reload(dpypelines.pipeline.config.job_configuration)
     from dpypelines.pipeline.config.job_configuration import JobConfiguration
+
+    secrets_client.return_value.get_secret.side_effect = get_secret
 
     mp = pytest.MonkeyPatch()
 
@@ -192,7 +194,7 @@ def test_should_load_env_vars_from_constructor(secrets_client):
 
 
 @patch("dpytools.secrets.secrets_client.SecretsClient")
-def test_should_exits_on_secret_error(secrets_client, monkeypatch):
+def test_raises_exception_on_secret_not_found_error(secrets_client, monkeypatch):
     """ """
     secrets_client.return_value.get_secret.side_effect = get_secret
 
@@ -206,50 +208,54 @@ def test_should_exits_on_secret_error(secrets_client, monkeypatch):
     reload(dpypelines.pipeline.config.job_configuration)
     from dpypelines.pipeline.config.job_configuration import JobConfiguration
 
-    config = JobConfiguration(
-        secrets_client=secrets_client(), secrets_config=secrets_with_missing
-    )
+    with pytest.raises(Exception) as e:
+        JobConfiguration(
+            secrets_client=secrets_client(), secrets_config=secrets_with_missing
+        )
 
-    assert config.error is not None
-    assert config.loaded
-
-    # Should not exist
-    with pytest.raises(AttributeError):
-        config.__getattribute__(missing_secret.secret_id)
-
-    # Since the missing secret was _last_ in the list, this _should_ exist
-    assert config.dataset_api_url is not None
-
-    # But these should be None since they will not have been retrieved:
-    assert config.disable_emails is None
-    assert config.disable_notifications is None
-    assert config.skip_data_upload is None
+    assert "Failed to retrieve secrets from AWS Secrets Manager. Error" in str(e.value)
 
 
 @patch("dpytools.secrets.secrets_client.SecretsClient")
-def test_should_exits_early_on_secret_error(secrets_client):
+def test_raises_exception_on_secret_key_missing_error(secrets_client, monkeypatch):
     """ """
     reload(dpypelines.pipeline.config.job_configuration)
     from dpypelines.pipeline.config.job_configuration import JobConfiguration
 
     secrets_client.return_value.get_secret.side_effect = get_secret
 
-    missing_secret = SecretConfig("THIS_SECRET_DOESNT_EXIST", "attr_should_not_be_set")
-    secrets_with_missing = [
-        missing_secret,
-        *secrets_config,
+    mp = pytest.MonkeyPatch()
+
+    mp.setenv("SKIP_DATA_UPLOAD", "True")
+    mp.setenv("DISABLE_NOTIFICATIONS", "True")
+    mp.setenv("DISABLE_EMAILS", "True")
+
+    test_environment_vars_config = [
+        # Environment var name, JobConfiguration attribute, default value
+        ("SKIP_DATA_UPLOAD", "skip_data_upload", True),
+        ("DISABLE_NOTIFICATIONS", "disable_notifications", True),
+        ("DISABLE_EMAILS", "disable_emails", True),
     ]
 
-    config = JobConfiguration(
-        secrets_client=secrets_client(), secrets_config=secrets_with_missing
+    secrets_client.return_value.get_secret.side_effect = get_secret
+
+    missing_secret_key = "missing_secret_key"
+    secret_config_copy = secrets_config.copy()
+    secret_config_copy[0].mappings.append(
+        SecretMapping(missing_secret_key, "some_config_attribute")
     )
 
-    assert config.error is not None
-    assert config.loaded
+    monkeypatch.setenv("SKIP_DATA_UPLOAD", "True")
+    monkeypatch.setenv("DISABLE_NOTIFICATIONS", "True")
+    monkeypatch.setenv("DISABLE_EMAILS", "True")
 
-    # Should not exist
-    with pytest.raises(AttributeError):
-        config.__getattribute__(missing_secret.secret_id)
+    reload(dpypelines.pipeline.config.job_configuration)
 
-    # Since the missing secret was _first_ in the list, this _should not_ exist as we should have already exited
-    assert config.dataset_api_url is None
+    with pytest.raises(AttributeError) as e:
+        JobConfiguration(
+            secrets_client=secrets_client(),
+            secrets_config=secret_config_copy,
+            environment_config=test_environment_vars_config,
+        )
+
+    assert f"Secret key '{missing_secret_key}' " in str(e.value)

--- a/tests/pipelines/pipeline/test_s3_folder_received.py
+++ b/tests/pipelines/pipeline/test_s3_folder_received.py
@@ -204,11 +204,10 @@ def test_start_fails_invalid_manifest(
     )
     mock_delete_s3_processing = MagicMock("delete_s3_processing")
     mock_delete_s3_processing.return_value = None
-    mock_error_handler = MagicMock("error_handler")
     mock_error_handler.return_value = None
     with pytest.raises(FileNotFoundError) as e:
         start("bucket/folder/file.zip")
     assert "Failed to retrieve manifest from the local directory store." in str(e)
-    mock_notifier.failure.assert_called_once()
+    mock_error_handler.assert_called_once()
     mock_process_zip_file.assert_called_once_with("bucket/folder/file.zip")
     mock_manifest_validation.assert_called_once_with(mock_local_store)

--- a/tests/pipelines/pipeline/test_validate_pipeline.py
+++ b/tests/pipelines/pipeline/test_validate_pipeline.py
@@ -16,9 +16,8 @@ from dpypelines.pipeline.validation.models import ValidationResult
 
 test_cases_base_dir = Path("tests/fixtures/test-cases")
 
-
 @patch("dpypelines.pipeline.validate_pipeline.LocalDirectoryStore")
-def test_retrieve_and_validate_manifest(mock_local_store):
+def test_validate_manifest(mock_local_store):
     mock_local_store = MagicMock(name="local_store")
     mock_local_store.get_lone_matching_json_as_dict.return_value = {
         "metadata_file": "metadata.json",
@@ -32,13 +31,12 @@ def test_retrieve_and_validate_manifest(mock_local_store):
 
 
 @patch("dpypelines.pipeline.validate_pipeline.LocalDirectoryStore")
-def test_retrieve_and_validate_manifest_file_not_found(mock_local_store):
+def test_validate_manifest_file_not_found(mock_local_store):
     mock_local_store = MagicMock(name="local_store")
     mock_local_store.get_lone_matching_json_as_dict.return_value = {}
     with pytest.raises(FileNotFoundError) as e:
         validate_manifest(mock_local_store)
     assert "Failed to retrieve manifest from the local directory store." in str(e)
-
 
 @patch("dpypelines.pipeline.validate_pipeline.validate_file_exists_and_not_empty")
 @patch("dpypelines.pipeline.validate_pipeline.validate_file_format")
@@ -88,13 +86,11 @@ def test_load_and_validate_metadata_invalid_metadata(
 
     assert "1 validation error for Metadata\ndataset_id" in str(e)
 
-
 def test_validate_manifest_schema_fails():
     manifest_dict = {"key": "value"}
     with pytest.raises(ValueError) as e:
         validate_manifest_schema(manifest_dict)
     assert "Manifest schema validation failed" in str(e)
-
 
 def test_read_json_file():
     """

--- a/tests/pipelines/pipeline/test_validate_pipeline.py
+++ b/tests/pipelines/pipeline/test_validate_pipeline.py
@@ -16,6 +16,7 @@ from dpypelines.pipeline.validation.models import ValidationResult
 
 test_cases_base_dir = Path("tests/fixtures/test-cases")
 
+
 @patch("dpypelines.pipeline.validate_pipeline.LocalDirectoryStore")
 def test_validate_manifest(mock_local_store):
     mock_local_store = MagicMock(name="local_store")
@@ -37,6 +38,7 @@ def test_validate_manifest_file_not_found(mock_local_store):
     with pytest.raises(FileNotFoundError) as e:
         validate_manifest(mock_local_store)
     assert "Failed to retrieve manifest from the local directory store." in str(e)
+
 
 @patch("dpypelines.pipeline.validate_pipeline.validate_file_exists_and_not_empty")
 @patch("dpypelines.pipeline.validate_pipeline.validate_file_format")
@@ -86,11 +88,13 @@ def test_load_and_validate_metadata_invalid_metadata(
 
     assert "1 validation error for Metadata\ndataset_id" in str(e)
 
+
 def test_validate_manifest_schema_fails():
     manifest_dict = {"key": "value"}
     with pytest.raises(ValueError) as e:
         validate_manifest_schema(manifest_dict)
     assert "Manifest schema validation failed" in str(e)
+
 
 def test_read_json_file():
     """
@@ -115,4 +119,5 @@ def test_read_json_file_invalid():
     with pytest.raises(ValueError) as e:
         read_json_file(file_path)
 
-    assert "File is not valid JSON" in str(e.value)
+    assert "not valid JSON" in str(e.value)
+    assert str(file_path) in str(e.value)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

#### Integration tests

Integration tests done where external services are mocked using pytest, and moto (for AWS). I believe this covers almost all, if not all, if the possible paths; if I've missed any please shout but let's cover that on a separate PR.

#### JobConfiguration

1. Modified to raise an exception in cases where:
  - The secret was not found in AWS Secrets Manager
  - A mapped key in the secret was not found in the secret
2. Amend how the default configs work (i.e. are returned from methods, not just global variables) for easier mocking

#### CI/CD - testing workflow

1. Amend the code coverage check to ensure that the code coverages is greater than or equal to 80%, not just greater than.
2. Add a step that runs the integration tests
 
#### Other

1. Couple of minor tweaks in places where `JobConfiguration` is used by another method/class to retrieve a variable, to simplify the code.
2. Make the string `"static"` its own object that is then referenced to, in the `check_dataset_type_is_static` method for best practices
3. Modify the `error_handler` method to raise the original exception thrown, not a new one. 
4. Modify the `makefile` so that:
  - Unit tests are a separate command
  - Integration tests are a separate command
  - The existing test command runs one and then the other [^1]

### Testing

Yes.

### Documentation

A minor README. If there's anything else y'all think would be appropriate please shout.

### Related issues

2835


[^1]: Running them all in one go causes problems because of the terrible idea to make `JobConfiguration` a singleton. This needs reworking, but for now the process actually works so this can be addressed in the future.