### PR TITLE
feat: Add csdb file type validator

### DIFF
--- a/dpypelines/pipeline/validation/csv_validator.py
+++ b/dpypelines/pipeline/validation/csv_validator.py
@@ -1,34 +1,61 @@
+from io import TextIOWrapper
 from dpypelines.pipeline.validation.file_format_validator import FileFormatValidator
 from dpypelines.pipeline.validation.models import ValidationResult
-
 
 import csv
 from pathlib import Path
 
-
 class CSVValidator(FileFormatValidator):
     def __init__(self):
-        super().__init__(["csv"])
+        super().__init__(["csv", "tsv"])
 
     def validate_file_format(self, file_path: Path) -> ValidationResult:
         """
-        Validate that the file has at least one row with one column in it.
+        Validate that the file is a valid CSV.
+
+        Args:
+            file_path: Path object representing the data file to validate
+
+        Returns:
+            ValidationResult with the validation result data
         """
         try:
-            with open(file_path, "r", newline="", encoding="utf-8") as f:
-                csv_reader = csv.reader(f)
-                header = next(csv_reader, None)
+            if file_path.stat().st_size == 0:
+                return self._generate_error(file_path, f"File '{str(file_path)}' is empty")
+            
+            with open(file_path, "r", newline="", encoding="utf-8") as file:
+                valid_csv = self._try_validate_with_sniffer(file)
 
-                if not header:
-                    return self._generate_error(
-                        file_path, "No header row found in CSV file"
+                return (
+                    self._generate_success(file_path)
+                    if valid_csv
+                    else self._generate_error(
+                        file_path, f"Could not parse {file_path} as a valid CSV"
                     )
-
-                if len(header) == 0:
-                    return self._generate_error(
-                        file_path, "No columns found in CSV file"
-                    )
-
-                return self._generate_success(file_path)
+                )
         except Exception as e:
             return self._generate_error(file_path, f"CSV validation error: {str(e)}")
+
+    def _try_validate_with_sniffer(self, file: TextIOWrapper) -> bool:
+        """
+        Try to "sniff" the format of the file, and then validate based on the sniffed dialect
+
+        Args:
+            file: The open file to try to validate
+
+        Returns:
+            bool: True == valid, False == invalid
+        """
+        try:
+            csv_test_bytes = file.read(1024)  # Grab a sample of the CSV for format detection.
+            file.seek(0)  # Rewind
+            has_header = csv.Sniffer().has_header(csv_test_bytes)  # Check to see if there's a header in the file.
+            dialect = csv.Sniffer().sniff(csv_test_bytes)  # Check what kind of csv/tsv file we have.
+            inputreader = csv.reader(file, dialect)
+            if has_header:
+                next(inputreader) # Skip the header if we have one.
+            for row in inputreader:
+                print(row)
+            return True
+        except csv.Error:
+            return False

--- a/dpypelines/pipeline/validation/file_validators.py
+++ b/dpypelines/pipeline/validation/file_validators.py
@@ -3,6 +3,7 @@ from .excel_validator import ExcelValidator
 from .json_validator import JSONValidator
 from .text_validator import TextValidator
 from .xml_validator import XMLValidator
+from .sqlite_validator import SQLiteValidator
 from .file_format_validator import FileFormatValidator
 
 
@@ -13,4 +14,5 @@ def get_file_validators() -> list[FileFormatValidator]:
         JSONValidator(),
         TextValidator(),
         XMLValidator(),
+        SQLiteValidator(),
     ]

--- a/dpypelines/pipeline/validation/models.py
+++ b/dpypelines/pipeline/validation/models.py
@@ -6,3 +6,15 @@ class ValidationResult:
         self.valid = valid
         self.format = format
         self.error = error
+
+    def __str__(self):
+        return f"[ValidationResult] valid:'{self.valid}', format:'{self.format}', error: {self._format_error()}"
+
+    def _format_error(self):
+        if self.error is None:
+            return "None"
+
+        return f"'{self.error}'"
+
+    def __repr__(self):
+        return self.__str__()

--- a/dpypelines/pipeline/validation/sqlite_validator.py
+++ b/dpypelines/pipeline/validation/sqlite_validator.py
@@ -1,0 +1,42 @@
+import sqlite3
+from dpypelines.pipeline.validation.file_format_validator import FileFormatValidator
+from dpypelines.pipeline.validation.models import ValidationResult
+
+
+from pathlib import Path
+
+
+class SQLiteValidator(FileFormatValidator):
+    def __init__(self):
+        super().__init__(["csdb", "sqlite", "db", "db3"])
+
+    def validate_file_format(self, file_path: Path) -> ValidationResult:
+        """
+        Validate that the file is a valid SQLite3 (or CSDB) file
+        """
+
+        "Needed because an empty file is still a valid sqlite3 DB (!) and there's no guarantees that the file was validated this way before"
+        if file_path.stat().st_size == 0:
+            return self._generate_error(file_path, "File is empty")
+
+        try:
+            conn = sqlite3.connect(f"file:{file_path}?mode=ro", uri=True)
+            cursor = conn.cursor()
+
+            result = self._verify_database_file(file_path, cursor)
+
+            cursor.close()
+            conn.close()
+
+            return result
+        except Exception as e:
+            return self._generate_error(file_path, str(e))
+
+    def _verify_database_file(
+        self, file_path: Path, cursor: sqlite3.Cursor
+    ) -> ValidationResult:
+        try:
+            cursor.execute("PRAGMA integrity_check")
+            return self._generate_success(file_path)
+        except sqlite3.DatabaseError as e:
+            return self._generate_error(file_path, str(e))

--- a/tests/pipelines/pipeline/shared/validation/base_test_file_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/base_test_file_validator.py
@@ -44,19 +44,23 @@ class BaseTestFileValidator:
         self.validate_success(result)
 
     def _test_validator_errors_empty_file(self):
-        file_path = self._get_test_file_path()
-        file_path.touch()
+        file_path = self._generate_empty_file()
         validator = self.validator_type()
 
         result = validator.validate_file_format(file_path)
 
         self.validate_error(result)
 
+    def _generate_empty_file(self):
+        file_path = self._get_test_file_path()
+        file_path.touch()
+        return file_path
+
     def test_validator_errors_invalid_file(self):
         file_path = self._get_test_file_path()
 
         with open(file_path, "w") as f:
-            f.write("this should fail everything except text")
+            f.write('\x00\nt\n"dsaasd,"\n\theader1#header2#header3\nvalue1#value2#value3')
 
         validator = self.validator_type()
 

--- a/tests/pipelines/pipeline/shared/validation/base_test_file_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/base_test_file_validator.py
@@ -52,6 +52,18 @@ class BaseTestFileValidator:
 
         self.validate_error(result)
 
+    def test_validator_errors_invalid_file(self):
+        file_path = self._get_test_file_path()
+
+        with open(file_path, "w") as f:
+            f.write("this should fail everything except text")
+
+        validator = self.validator_type()
+
+        result = validator.validate_file_format(file_path)
+
+        self.validate_error(result)
+
     def validate_error(self, result: ValidationResult, error: Optional[str] = None):
         assert not result.valid
         assert result.error is not None if error is None else error

--- a/tests/pipelines/pipeline/shared/validation/test_csv_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/test_csv_validator.py
@@ -1,20 +1,50 @@
 import csv
+from io import StringIO
 from pathlib import Path
+
+import pytest
 from dpypelines.pipeline.validation.csv_validator import CSVValidator
 from tests.pipelines.pipeline.shared.validation.base_test_file_validator import (
     BaseTestFileValidator,
 )
 
+test_data = {
+    "headers": ["header1", "header2", "header3"],
+    "rows": [["value1", "value2", "value3"]]
+}
 
 class TestCSVValidator(BaseTestFileValidator):
     file_format: str = "csv"
     validator_type = CSVValidator
-
+    
+    def create_csv(self, delimiter: str) -> StringIO:
+        headers = delimiter.join(test_data["headers"])
+        rows = "\n".join(delimiter.join(row) for row in test_data["rows"])
+        
+        return headers + "\n" + rows
+    
+    @pytest.fixture
+    def valid_csv_file(self):
+        return StringIO(self.create_csv(","))
+    
+    @pytest.fixture
+    def valid_tsv_file(self):
+        return StringIO(self.create_csv("\n"))
+    
+    @pytest.fixture
+    def valid_semicolon_file(self):
+        return StringIO(self.create_csv(";"))
+    
+    @pytest.fixture
+    def invalid_file(self):
+        return StringIO("{this is some other file}")
+    
     def generate_test_file(self, file_path: Path):
         with open(file_path, "w", newline="") as csvfile:
             writer = csv.writer(csvfile)
-            writer.writerow(["id", "name", "value"])
-
+            writer.writerow(test_data["headers"])
+            writer.writerows(test_data["rows"])
+            
     def test_validator_passes_valid_file(self):
         """Test that CSV files are validated with the CSV validator."""
         self._test_validator_passes_valid_file()
@@ -23,3 +53,32 @@ class TestCSVValidator(BaseTestFileValidator):
     def test_validator_errors_empty_file(self):
         """Test that CSV files are validated with the CSV validator."""
         self._test_validator_errors_empty_file()
+
+    def test_sniffer_valid_csv(self):
+        file = StringIO(self.create_csv(","))
+        validator = CSVValidator()
+        
+        result = validator._try_validate_with_sniffer(file)
+        
+        assert result is True
+    
+    def test_sniffer_valid_tsv(self):
+        file = StringIO(self.create_csv("\n"))
+        validator = CSVValidator()
+
+        result = validator._try_validate_with_sniffer(file)
+        assert result is True
+    
+    def test_sniffer_valid_semicolon(self):
+        file = StringIO(self.create_csv(";"))
+        validator = CSVValidator()
+        
+        result = validator._try_validate_with_sniffer(file)
+        
+        assert result is True
+    
+    def test_sniffer_invalid_csv(self, invalid_file):
+        validator = CSVValidator()
+
+        result = validator._try_validate_with_sniffer(invalid_file)
+        assert isinstance(result, bool) 

--- a/tests/pipelines/pipeline/shared/validation/test_models.py
+++ b/tests/pipelines/pipeline/shared/validation/test_models.py
@@ -1,0 +1,25 @@
+import pytest
+from dpypelines.pipeline.validation.models import ValidationResult
+
+test_data = [
+    (True, "csv", None),
+    (True, "other-format", None),
+    (True, "excel", "Should't be an error here but doesn't matter"),
+    (False, "json", "Some error here"),
+    (False, "xls", "")
+]
+
+@pytest.mark.parametrize("success,format,error", test_data)
+def test_should_write_success_to_string(success: bool, format: str, error):
+    result = ValidationResult(success, format, error)
+    
+    result_string = result.__repr__()
+
+    assert "[ValidationResult]" in result_string, result_string
+    assert str(success) in result_string, result_string
+    assert str(not success) not in result_string, result_string
+    assert format in result_string, result_string
+    if error is None:
+        assert "error: None" in result_string
+    else:
+        assert f"'{error}'" in result_string, result_string

--- a/tests/pipelines/pipeline/shared/validation/test_sqlite_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/test_sqlite_validator.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import sqlite3
+from dpypelines.pipeline.validation.sqlite_validator import SQLiteValidator
+from tests.pipelines.pipeline.shared.validation.base_test_file_validator import (
+    BaseTestFileValidator,
+)
+
+
+class TestSQLiteValidator(BaseTestFileValidator):
+    file_format: str = "csdb"
+    validator_type = SQLiteValidator
+
+    def generate_test_file(self, file_path: Path):
+        conn = sqlite3.connect(str(file_path))
+        cursor = conn.cursor()
+        cursor.execute("CREATE TABLE dummy_table(id)")
+        conn.close()
+
+    def test_validator_passes_valid_file(self):
+        """Test that sqlite files are validated with the sqlite validator."""
+        self._test_validator_passes_valid_file()
+        assert True
+
+    def test_validator_errors_empty_file(self):
+        """Test that sqlite files are validated with the sqlite validator."""
+        self._test_validator_errors_empty_file()

--- a/tests/pipelines/pipeline/shared/validation/test_sqlite_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/test_sqlite_validator.py
@@ -24,3 +24,9 @@ class TestSQLiteValidator(BaseTestFileValidator):
     def test_validator_errors_empty_file(self):
         """Test that sqlite files are validated with the sqlite validator."""
         self._test_validator_errors_empty_file()
+
+    def test_handles_sqlite_error(self):
+        file_path = self._get_test_file_path()
+
+        with open(file_path, "w") as f:
+            f.write("this is not a sqlite file")

--- a/tests/pipelines/pipeline/shared/validation/test_text_validator.py
+++ b/tests/pipelines/pipeline/shared/validation/test_text_validator.py
@@ -34,3 +34,6 @@ class TestXMLValidator(BaseTestFileValidator):
         result = validator.validate_file_format(file_path)
 
         self.validate_error(result)
+
+    def test_validator_errors_invalid_file(self):
+        pass


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

1. Adds validator for csdb/sqlite3 files, as this was missing from the previous work.
2. Improve `CSVValidator` validation. It would pass if a file was a text file (without a comma etc)
3. Add an extra test case for all validators (except `TextValidator`, as that's really unlikely to be used) that validates against a normal text file.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [x] Yes
- [ ] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)