### PR TITLE
fix(dataset): Make release_date a str

### DIFF
--- a/dpypelines/pipeline/models.py
+++ b/dpypelines/pipeline/models.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import List, Optional
 
 from pydantic import BaseModel, EmailStr, Field
@@ -9,7 +8,7 @@ from dpypelines.pipeline.messages.utils import get_mimetype
 class DatasetVersion(BaseModel):
     edition_title: str
     distributions: List["Distribution"]
-    release_date: datetime
+    release_date: str
     quality_designation: Optional[str] = None
     usage_notes: Optional[List["UsageNote"]] = Field(default_factory=list)
     alerts: Optional[List["Alert"]] = Field(default_factory=list)

--- a/tests/pipelines/pipeline/test_dataset_api.py
+++ b/tests/pipelines/pipeline/test_dataset_api.py
@@ -1,4 +1,3 @@
-import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -142,7 +141,7 @@ def test_upload_metadata_succeeds(mock_DatasetAPIClient):
             ],
             "edition_title": "Edition title",
             "quality_designation": None,
-            "release_date": datetime.datetime(2025, 1, 1, 0, 0),
+            "release_date": "2025-01-01T00:00:00",
             "usage_notes": [],
         }
     )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Changes `release_date` from a `datetime` field to a `str`.

1. Reduces problems with `datetime` JSON serialisation 
2. Move validation of the field to the DatasetAPI

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

Updated relevant tests.