### PR TITLE
feat: Retrieve existing metadata from Datasets API if necessary

### DIFF
--- a/dpypelines/pipeline/dataset_api.py
+++ b/dpypelines/pipeline/dataset_api.py
@@ -1,113 +1,82 @@
-import json
-
-from dpytools.http.api.dataset_api_client import DatasetAPIClient
+from dpytools.http.api.dataset_api_service import DatasetAPIService
 from dpytools.logging.logger import DpLogger
 
-from dpypelines.pipeline.config import JobConfiguration
 from dpypelines.pipeline.errors import (
     DatasetNotFoundException,
-    DatasetTypeException,
 )
+from dpypelines.pipeline.errors.dataset_type_exception import DatasetTypeException
 from dpypelines.pipeline.models.metadata_models import DatasetVersion, Metadata
+from dpytools.http.api.models.dataset import DatasetType
 
 logger = DpLogger("data-ingress-pipelines")
 
 
-def validate_and_upload_metadata(metadata: Metadata) -> bool:
+def validate_and_upload_metadata(
+    metadata: Metadata,
+    dataset_api_service: DatasetAPIService,
+) -> bool:
     """
     Verify that the required conditions are met for the metadata to be uploaded the the Dataset API and submit the `POST` request with the required parameters.
     """
-    dataset_api_url = JobConfiguration().dataset_api_url
-    if not dataset_api_url:
-        msg = "Required variable not set: DATASET_API_URL"
-        raise EnvironmentError(msg)
-
-    dataset_api_client = DatasetAPIClient(
-        dataset_api_url, metadata.dataset_id, metadata.edition
-    )
-
-    if not is_valid_dataset(dataset_api_client):
+    if not is_valid_dataset(metadata.dataset_id, dataset_api_service):
         return False
 
-    return upload_metadata(metadata, dataset_api_client)
+    return upload_metadata(metadata, dataset_api_service)
 
 
-def upload_metadata(metadata: Metadata, dataset_api_client: DatasetAPIClient) -> bool:
+def upload_metadata(
+    metadata: Metadata,
+    dataset_api_service: DatasetAPIService,
+) -> bool:
     """
     Send a `POST` request to the `datasets/{dataset_id}/editions/{edition_id}/versions` endpoint to submit the metadata.
     """
     request_body = DatasetVersion(**metadata.model_dump()).model_dump()
-    post_metadata_response = dataset_api_client.post_json(request_body)
+    post_metadata_response = dataset_api_service.versions.create_version(
+        request_body, dataset_id=metadata.dataset_id, edition_id=metadata.edition
+    )
     post_metadata_response.raise_for_status()
     logger.info(
         "Metadata submitted to Dataset API endpoint",
-        data={"dataset_api_endpoint": dataset_api_client.full_url},
+        data={
+            "dataset_api_endpoint": dataset_api_service.versions._build_full_url(
+                dataset_id=metadata.dataset_id, edition_id=metadata.edition
+            )
+        },
     )
     return True
 
 
-def is_valid_dataset(dataset_api_client: DatasetAPIClient) -> bool:
+def is_valid_dataset(dataset_id: str, dataset_api_service: DatasetAPIService) -> bool:
     """
     Verify that the `datasets/{dataset_id}/editions/{edition_id}/versions` endpoint exists and that the dataset type is `static`.
     """
-    return dataset_versions_path_exists(dataset_api_client) and dataset_type_is_static(
-        dataset_api_client
-    )
+    return dataset_type_is_static(dataset_id, dataset_api_service)
 
 
-def dataset_versions_path_exists(dataset_api_client: DatasetAPIClient) -> bool:
-    """
-    Send a `GET` request to the `datasets/{dataset_id}/editions/{edition_id}/versions` endpoint to confirm existence.
-    """
-    get_full_path_response = dataset_api_client.get_path()
-    get_full_path_response.raise_for_status()
-    logger.info(
-        "Dataset API endpoint exists",
-        data={"dataset_api_endpoint": dataset_api_client.full_url},
-    )
-    return True
-
-
-def dataset_type_is_static(dataset_api_client: DatasetAPIClient) -> bool:
+def dataset_type_is_static(
+    dataset_id: str, dataset_api_service: DatasetAPIService
+) -> bool:
     """
     Return a boolean specifying whether the dataset type is `static` (True) or not (False).
 
     If either `get_dataset_id_path_response` or `get_current_dataset_type` fail to generate the required values, raise an error.
     """
-    dataset_id_path_response = get_dataset_id_path_response(dataset_api_client)
-    if not dataset_id_path_response:
+    dataset = dataset_api_service.datasets.get_dataset(dataset_id)
+    if not dataset:
         raise DatasetNotFoundException(
-            "Dataset not found", dataset_path=dataset_api_client.dataset_path
+            "Dataset not found",
+            dataset_path=dataset_api_service.datasets._build_full_url(dataset_id),
         )
 
-    dataset_type = get_current_dataset_type(dataset_id_path_response)
-    if not dataset_type:
-        raise DatasetTypeException("Dataset type error", dataset_type=str(dataset_type))
-
-    return dataset_type == "static"
-
-
-def get_dataset_id_path_response(dataset_api_client: DatasetAPIClient) -> dict:
-    """
-    Send a `GET` request to the `datasets/{dataset-id}` endpoint and load the result text as a dict.
-    """
-    get_dataset_result = dataset_api_client.get(
-        f"{dataset_api_client.dataset_api_url}/{dataset_api_client.dataset_path}",
-        headers=dataset_api_client.token_auth.get_auth_header(),
-    )
-    if get_dataset_result.status_code != 200:
-        get_dataset_result.raise_for_status()
-        return
-
-    return json.loads(get_dataset_result.text)
-
-
-def get_current_dataset_type(dataset_result: dict) -> str:
-    """
-    Check that the result returned by `get_dataset_id_path_response` contains a `current` object, and get the value of `type` in this object.
-    """
-    current_dataset = dataset_result.get("current", None)
-    if current_dataset:
-        return current_dataset.get("type", None)
-    else:
+    if dataset.current is None:
         raise KeyError("'current' not found in dataset_result keys")
+
+    dataset_type = dataset.current.type
+
+    if dataset_type is None:
+        raise DatasetTypeException(
+            f"No dataset type found in dataset {dataset_id}", dataset_type
+        )
+
+    return dataset_type == DatasetType.STATIC or dataset_type == "static"

--- a/dpypelines/pipeline/metadata/metadata_loader.py
+++ b/dpypelines/pipeline/metadata/metadata_loader.py
@@ -1,0 +1,127 @@
+from typing import Dict, Any
+from dpypelines.pipeline.models.metadata_models import (
+    Distribution,
+    Manifest,
+    Metadata,
+    MinimalMetadata,
+)
+from dpytools.stores.directory.local import LocalDirectoryStore
+from dpytools.http.api.dataset_api_service import DatasetAPIService
+from dpytools.http.api.models.version import DatasetVersion
+from dpypelines.pipeline.shared.files.json_file_readers import read_json_file
+from dpytools.logging.logger import DpLogger
+from dpypelines.pipeline.validation.utils import (
+    validate_file_format,
+    validate_file_exists_and_not_empty,
+)
+
+
+class MetadataLoader:
+    def __init__(self, dataset_api_service: DatasetAPIService, logger: DpLogger):
+        self.dataset_api_service = dataset_api_service
+        self.logger = logger
+
+    def load_metadata(
+        self, manifest: Manifest, local_store: LocalDirectoryStore
+    ) -> Metadata:
+        """
+        Load metadata from file, retrieve latest version from API, combine if necessary, and validate distributions files.
+        """
+        metadata_dict = self.__load_metadata_from_file(
+            manifest.metadata_file, local_store
+        )
+        minimal_metadata = MinimalMetadata(**metadata_dict)
+        latest_version = self.__get_latest_version_metadata_from_api(minimal_metadata)
+
+        metadata = (
+            Metadata(**metadata_dict)
+            if not manifest.use_previous_metadata
+            else self.__combine_metadata(metadata_dict, latest_version)
+        )
+
+        self.validate_distributions(metadata, local_store)
+        return metadata
+
+    def __load_metadata_from_file(
+        self, metadata_file: str, local_store: LocalDirectoryStore
+    ) -> dict:
+        """
+        Validate the manifest file and then reads + deserialises JSON to Metadata instance.
+        """
+        validate_file_exists_and_not_empty(
+            local_store.local_path.absolute() / metadata_file
+        )
+
+        metadata_dict = read_json_file(
+            local_store.local_path.absolute() / metadata_file
+        )
+
+        return metadata_dict
+
+    def __combine_metadata(
+        self, metadata_file_dict: Dict[str, Any], existing_metadata: DatasetVersion
+    ) -> Metadata:
+        """
+        Get latest metadata from the Dataset API, then overwrite with any values from the metadata file.
+
+        Args:
+            metadata_file_dict: JSON from the metadata file that was uploaded
+        """
+        combined_metadata = existing_metadata.model_dump()
+        combined_metadata.update(metadata_file_dict)
+        metadata = Metadata(**combined_metadata)
+        return metadata
+
+    def __get_latest_version_metadata_from_api(
+        self, minimal_metadata: MinimalMetadata
+    ) -> DatasetVersion:
+        """
+        Get the latest version of the Dataset edition from the Dataset API
+
+        Args:
+            minimal_metadata: The minimal metadata we require to retrieve the latest version from the Dataset API
+        """
+        existing_metadata = self.dataset_api_service.versions.get_versions(
+            dataset_id=minimal_metadata.dataset_id, edition_id=minimal_metadata.edition
+        )
+
+        if not existing_metadata.items or len(existing_metadata.items) == 0:
+            raise ValueError(
+                f"Could not find existing version for dataset {minimal_metadata.dataset_id}, edition {minimal_metadata.edition}"
+            )
+
+        latest_version = existing_metadata.get_latest_version()
+        if latest_version is None:
+            raise ValueError(
+                f"Could not find latest version for dataset {minimal_metadata.dataset_id}, edition {minimal_metadata.edition}"
+            )
+
+        return latest_version
+
+    def validate_distributions(
+        self, metadata: Metadata, local_store: LocalDirectoryStore
+    ):
+        for distribution in metadata.distributions:
+            self.validate_distribution_file(distribution, local_store)
+
+        self.logger.info("Metadata and data files validated.")
+
+    def validate_distribution_file(
+        self, distribution: Distribution, local_store: LocalDirectoryStore
+    ) -> None:
+        self.logger.info(f"Validating distribution file {distribution.file}")
+        file_path = local_store.local_path.absolute() / distribution.file
+
+        validate_file_exists_and_not_empty(file_path)
+        self.logger.info("Data file found", data={"data_file_name": distribution.file})
+
+        validation_result = validate_file_format(file_path)
+        if not validation_result.valid or validation_result.error:
+            raise ValueError(
+                f"File format validation failed for {distribution.file}: {validation_result.error}"
+            )
+
+        self.logger.info(
+            f"Validated file format for {distribution.file}",
+            data={"format": validation_result.format},
+        )

--- a/dpypelines/pipeline/models/metadata_models.py
+++ b/dpypelines/pipeline/models/metadata_models.py
@@ -5,31 +5,12 @@ from pydantic import BaseModel, EmailStr, Field
 from dpypelines.pipeline.messages.utils import get_mimetype
 
 
-class DatasetVersion(BaseModel):
-    edition_title: str
-    distributions: List["Distribution"]
-    release_date: str
-    quality_designation: Optional[str] = None
-    usage_notes: Optional[List["UsageNote"]] = Field(default_factory=list)
-    alerts: Optional[List["Alert"]] = Field(default_factory=list)
-
-
-class Metadata(DatasetVersion):
-    dataset_id: str
-    edition: str
-
-
-class Manifest(BaseModel):
-    metadata_file: str
-    submission_contacts: List["SubmissionContact"]
-
-
 class Distribution(BaseModel):
     title: str
     format: str
     file: str
-    download_url: str = Field(default=None, init=False)
-    media_type: str = Field(default=None, init=False)
+    download_url: Optional[str] = Field(default=None, init=False)
+    media_type: Optional[str] = Field(default=None, init=False)
 
     def model_post_init(self, __context):
         self.download_url = f"https://download.ons.gov.uk/{self.file}"
@@ -42,9 +23,36 @@ class Alert(BaseModel):
 
 
 class UsageNote(BaseModel):
-    title: str
-    note: str
+    title: Optional[str] = None
+    note: Optional[str] = None
 
 
 class SubmissionContact(BaseModel):
     email: EmailStr
+
+
+class DatasetVersion(BaseModel):
+    edition_title: Optional[str] = None
+    quality_designation: Optional[str] = None
+    usage_notes: Optional[List[UsageNote]] = Field(default_factory=list)
+    alerts: Optional[List[Alert]] = Field(default_factory=list)
+    distributions: List[Distribution]
+    release_date: str
+
+
+class Metadata(DatasetVersion):
+    dataset_id: str
+    edition: str
+
+
+class MinimalMetadata(BaseModel):
+    dataset_id: str
+    edition: str
+    distributions: List[Distribution]
+    release_date: str
+
+
+class Manifest(BaseModel):
+    metadata_file: str
+    submission_contacts: List[SubmissionContact]
+    use_previous_metadata: bool = False

--- a/dpypelines/pipeline/shared/files/json_file_readers.py
+++ b/dpypelines/pipeline/shared/files/json_file_readers.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+
+
+def read_json_file(file_path: Path) -> dict:
+    """Validate and parse JSON file."""
+    try:
+        with open(file_path) as f:
+            data = json.load(f)
+        return data
+    except json.JSONDecodeError as e:
+        raise ValueError(f"File {file_path} is not valid JSON: {str(e)}")

--- a/dpypelines/pipeline/validate_pipeline.py
+++ b/dpypelines/pipeline/validate_pipeline.py
@@ -1,14 +1,8 @@
-import json
 from pathlib import Path
-
 from dpytools.logging.logger import DpLogger
 from dpytools.stores.directory.local import LocalDirectoryStore
 from dpytools.validation.json.validation import validate_json_schema
-
-from dpypelines.pipeline.models.metadata_models import Distribution, Manifest, Metadata
-from dpypelines.pipeline.validation.utils import validate_file_format
-from dpypelines.pipeline.validation.models import ValidationResult
-from dpypelines.pipeline.validation.utils import validate_file_exists_and_not_empty
+from dpypelines.pipeline.models.metadata_models import Manifest
 
 logger = DpLogger("data-ingress-pipeline")
 
@@ -50,65 +44,3 @@ def validate_manifest_schema(manifest_dict: dict) -> None:
         )
     except Exception as e:
         raise ValueError(f"Manifest schema validation failed: {e}")
-
-
-def load_and_validate_metadata(
-    manifest: Manifest, local_store: LocalDirectoryStore
-) -> Metadata:
-    """
-    Main validation function that returns validated objects.
-    """
-    # Retrieve and validate metadata.json
-    metadata = load_metadata(manifest, local_store)
-
-    # Retrieve and validate data files
-    for distribution in metadata.distributions:
-        validate_distribution_file(distribution, local_store)
-
-    logger.info("Metadata and data files validated.")
-    return metadata
-
-
-def validate_distribution_file(
-    distribution: Distribution, local_store: LocalDirectoryStore
-) -> ValidationResult:
-    logger.info(f"Validating distribution file {distribution.file}")
-    file_path = local_store.local_path.absolute() / distribution.file
-
-    validate_file_exists_and_not_empty(file_path)
-    logger.info("Data file found", data={"data_file_name": distribution.file})
-
-    validation_result = validate_file_format(file_path)
-    if not validation_result.valid or validation_result.error:
-        raise ValueError(
-            f"File format validation failed for {distribution.file}: {validation_result.error}"
-        )
-    logger.info(
-        f"Validated file format for {distribution.file}",
-        data={"format": validation_result.format},
-    )
-
-
-def load_metadata(manifest: Manifest, local_store: LocalDirectoryStore) -> Metadata:
-    """
-    Validates the manifest file and then reads + deserialises JSON to Metadata instance.
-    """
-    validate_file_exists_and_not_empty(
-        local_store.local_path.absolute() / manifest.metadata_file
-    )
-
-    metadata_dict = read_json_file(
-        local_store.local_path.absolute() / manifest.metadata_file
-    )
-
-    return Metadata.model_validate(metadata_dict)
-
-
-def read_json_file(file_path: Path) -> dict:
-    """Validate and parse JSON file."""
-    try:
-        with open(file_path) as f:
-            data = json.load(f)
-        return data
-    except json.JSONDecodeError as e:
-        raise ValueError(f"File {file_path} is not valid JSON: {str(e)}")

--- a/dpypelines/s3_folder_received.py
+++ b/dpypelines/s3_folder_received.py
@@ -3,6 +3,7 @@ from dpytools.logging.logger import DpLogger
 from dpypelines.pipeline.config import JobConfiguration
 from dpypelines.pipeline.dataset_api import validate_and_upload_metadata
 from dpypelines.pipeline.messages.error_handler_module import error_handler
+from dpypelines.pipeline.metadata.metadata_loader import MetadataLoader
 from dpypelines.pipeline.process_zip_file import (
     copy_s3_processing_folder_to_destination_folder,
     delete_s3_processing_folder,
@@ -15,8 +16,8 @@ from dpypelines.pipeline.utils import (
 )
 from dpypelines.pipeline.validate_pipeline import (
     validate_manifest,
-    load_and_validate_metadata,
 )
+from dpytools.http.api.dataset_api_service import DatasetAPIService
 
 logger = DpLogger("data-ingress-pipeline")
 
@@ -24,6 +25,15 @@ logger = DpLogger("data-ingress-pipeline")
 ENABLE_NOTIFICATION = True
 ENABLE_LOGS = True
 ENABLE_EMAIL = True
+
+
+def get_dataset_api_service():
+    dataset_api_url = JobConfiguration().dataset_api_url
+    if not dataset_api_url:
+        msg = "Required variable not set: DATASET_API_URL"
+        raise EnvironmentError(msg)
+    dataset_api_service = DatasetAPIService(dataset_api_url)
+    return dataset_api_service
 
 
 def start(s3_object_name: str, *args, **kwargs):
@@ -46,16 +56,21 @@ def start(s3_object_name: str, *args, **kwargs):
         local_store, decompressed_file_dir, s3_processing_folder = process_zip_file(
             s3_object_name
         )
+        dataset_api_service = get_dataset_api_service()
 
         # Validate configuration and files.
         manifest = validate_manifest(local_store)
-        metadata = load_and_validate_metadata(manifest, local_store)
+        metadata = MetadataLoader(dataset_api_service, logger).load_metadata(
+            manifest, local_store
+        )
 
         # Upload metadata to Dataset API.
         if not JobConfiguration().skip_data_upload:
             metadata_submitted = validate_and_upload_metadata(
-                metadata,
+                metadata=metadata,
+                dataset_api_service=dataset_api_service,
             )
+
             if metadata_submitted:
                 # If metadata successfully submitted, upload data files to the Upload Service
                 files_to_upload = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1374,6 +1374,24 @@ pytest = ">=6.2.5"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-responses"
+version = "0.5.1"
+description = "py.test integration for responses"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "pytest_responses-0.5.1-py2.py3-none-any.whl", hash = "sha256:4172e565b94ac1ea3b10aba6e40855ad60cd7f141476b2d8a47e4b5f250be734"},
+]
+
+[package.dependencies]
+pytest = ">=2.5"
+responses = "*"
+
+[package.extras]
+tests = ["flake8"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"

--- a/poetry.lock
+++ b/poetry.lock
@@ -46,18 +46,18 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.38.22"
+version = "1.38.24"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "boto3-1.38.22-py3-none-any.whl", hash = "sha256:760c85ab6dd78f12aa669269ca917d313fe02378722dc3b8ab41a8dc13b2a999"},
-    {file = "boto3-1.38.22.tar.gz", hash = "sha256:008f6a7c2f9f306984f9bd00c331d70341124aaa7dfebcb0466ecbda6619884a"},
+    {file = "boto3-1.38.24-py3-none-any.whl", hash = "sha256:1f95ec3ac88ae6381fa0409e4c2ad0a41f0caf5fd6d8ef45a9525406a3f58b18"},
+    {file = "boto3-1.38.24.tar.gz", hash = "sha256:abdb8c760543e9c22026320e62e2934762b0c4ac4f42e8ea2a756f2d489b3135"},
 ]
 
 [package.dependencies]
-botocore = ">=1.38.22,<1.39.0"
+botocore = ">=1.38.24,<1.39.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.13.0,<0.14.0"
 
@@ -66,14 +66,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.38.22"
+version = "1.38.24"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "botocore-1.38.22-py3-none-any.whl", hash = "sha256:0e524cc763eced7c87ab256338ebd247ce10d1eb11d5cc4f71a3bd82611739e8"},
-    {file = "botocore-1.38.22.tar.gz", hash = "sha256:3b464984674f97367ca1dfa29bdbce499327571208aaec2f9743f66e54d9ba05"},
+    {file = "botocore-1.38.24-py3-none-any.whl", hash = "sha256:5901667b96d3a8603479879ab097560216cdc4c2918d433fc6509555d0ada29c"},
+    {file = "botocore-1.38.24.tar.gz", hash = "sha256:43563d5c2dfd56ebbcd9e25f482fc45000bfaec5966b26c77b331bd340c46376"},
 ]
 
 [package.dependencies]
@@ -306,75 +306,79 @@ files = [
 
 [[package]]
 name = "coverage"
-version = "7.8.1"
+version = "7.8.2"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "coverage-7.8.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d7af3990490982fbd2437156c69edbe82b7edf99bc60302cceeeaf79afb886b8"},
-    {file = "coverage-7.8.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c5757a7b25fe48040fa120ba6597f5f885b01e323e0d13fe21ff95a70c0f76b7"},
-    {file = "coverage-7.8.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8f105631835fdf191c971c4da93d27e732e028d73ecaa1a88f458d497d026cf"},
-    {file = "coverage-7.8.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:21645788c5c2afa3df2d4b607638d86207b84cb495503b71e80e16b4c6b44e80"},
-    {file = "coverage-7.8.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e93f36a5c9d995f40e9c4cd9bbabd83fd78705792fa250980256c93accd07bb6"},
-    {file = "coverage-7.8.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d591f2ddad432b794f77dc1e94334a80015a3fc7fa07fd6aed8f40362083be5b"},
-    {file = "coverage-7.8.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:be2b1a455b3ecfee20638289bb091a95216887d44924a41c28a601efac0916e8"},
-    {file = "coverage-7.8.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:061a3bf679dc38fe34d3822f10a9977d548de86b440010beb1e3b44ba93d20f7"},
-    {file = "coverage-7.8.1-cp310-cp310-win32.whl", hash = "sha256:12950b6373dc9dfe1ce22a8506ec29c82bfc5b38146ced0a222f38cf5d99a56d"},
-    {file = "coverage-7.8.1-cp310-cp310-win_amd64.whl", hash = "sha256:11e5ea0acd8cc5d23030c34dfb2eb6638ad886328df18cc69f8eefab73d1ece5"},
-    {file = "coverage-7.8.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc6bebc15c3b275174c66cf4e1c949a94c5c2a3edaa2f193a1225548c52c771"},
-    {file = "coverage-7.8.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d8a6c35afd5b912101fabf42975d92d750cfce33c571508a82ff334a133c40d5"},
-    {file = "coverage-7.8.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b37729ba34c116a3b2b6fb99df5c37a4ca40e96f430070488fd7a1077ad44907"},
-    {file = "coverage-7.8.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b6424c716f4c38ff8f62b602e6b94cde478dadda542a1cb3fe2fe2520cc2aae3"},
-    {file = "coverage-7.8.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8bcfafb2809cd01be8ffe5f962e01b0fbe4cc1d74513434c52ff2dd05b86d492"},
-    {file = "coverage-7.8.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e3f65da9701648d226b6b24ded3e2528b72075e48d7540968cd857c3bd4c5321"},
-    {file = "coverage-7.8.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:173e16969f990688aae4b4487717c44330bc57fd8b61a6216ce8eeb827eb5c0d"},
-    {file = "coverage-7.8.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3763b9a4bc128f72da5dcfd7fcc7c7d6644ed28e8f2db473ce1ef0dd37a43fa9"},
-    {file = "coverage-7.8.1-cp311-cp311-win32.whl", hash = "sha256:d074380f587360d2500f3b065232c67ae248aaf739267807adbcd29b88bdf864"},
-    {file = "coverage-7.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:cd21de85aa0e247b79c6c41f8b5541b54285550f2da6a9448d82b53234d3611b"},
-    {file = "coverage-7.8.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d8f844e837374a9497e11722d9eb9dfeb33b1b5d31136786c39a4c1a3073c6d"},
-    {file = "coverage-7.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9cd54a762667c32112df5d6f059c5d61fa532ee06460948cc5bcbf60c502f5c9"},
-    {file = "coverage-7.8.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:958b513e23286178b513a6b4d975fe9e7cddbcea6e5ebe8d836e4ef067577154"},
-    {file = "coverage-7.8.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9b31756ea647b6ef53190f6b708ad0c4c2ea879bc17799ba5b0699eee59ecf7b"},
-    {file = "coverage-7.8.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ccad4e29ac1b6f75bfeedb2cac4860fe5bd9e0a2f04c3e3218f661fa389ab101"},
-    {file = "coverage-7.8.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:452f3831c64f5f50260e18a89e613594590d6ceac5206a9b7d76ba43586b01b3"},
-    {file = "coverage-7.8.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9296df6a33b8539cd753765eb5b47308602263a14b124a099cbcf5f770d7cf90"},
-    {file = "coverage-7.8.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d52d79dfd3b410b153b6d65b0e3afe834eca2b969377f55ad73c67156d35af0d"},
-    {file = "coverage-7.8.1-cp312-cp312-win32.whl", hash = "sha256:ebdf212e1ed85af63fa1a76d556c0a3c7b34348ffba6e145a64b15f003ad0a2b"},
-    {file = "coverage-7.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:c04a7903644ccea8fa07c3e76db43ca31c8d453f93c5c94c0f9b82efca225543"},
-    {file = "coverage-7.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:dd5c305faa2e69334a53061b3168987847dadc2449bab95735242a9bde92fde8"},
-    {file = "coverage-7.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:af6b8cdf0857fd4e6460dd6639c37c3f82163127f6112c1942b5e6a52a477676"},
-    {file = "coverage-7.8.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e233a56bbf99e4cb134c4f8e63b16c77714e3987daf2c5aa10c3ba8c4232d730"},
-    {file = "coverage-7.8.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9dabc70012fd7b58a8040a7bc1b5f71fd0e62e2138aefdd8367d3d24bf82c349"},
-    {file = "coverage-7.8.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1f8e96455907496b3e4ea16f63bb578da31e17d2805278b193525e7714f17f2"},
-    {file = "coverage-7.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0034ceec8e91fdaf77350901cc48f47efd00f23c220a3f9fc1187774ddf307cb"},
-    {file = "coverage-7.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:82db9344a07dd9106796b9fe8805425633146a7ea7fed5ed07c65a64d0bb79e1"},
-    {file = "coverage-7.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9772c9e266b2ca4999180c12b90c8efb4c5c9ad3e55f301d78bc579af6467ad9"},
-    {file = "coverage-7.8.1-cp313-cp313-win32.whl", hash = "sha256:6f24a1e2c373a77afae21bc512466a91e31251685c271c5309ee3e557f6e3e03"},
-    {file = "coverage-7.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:76a4e1d62505a21971968be61ae17cbdc5e0c483265a37f7ddbbc050f9c0b8ec"},
-    {file = "coverage-7.8.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:35dd5d405a1d378c39f3f30f628a25b0b99f1b8e5bdd78275df2e7b0404892d7"},
-    {file = "coverage-7.8.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:87b86a87f8de2e1bd0bcd45faf1b1edf54f988c8857157300e0336efcfb8ede6"},
-    {file = "coverage-7.8.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce4553a573edb363d5db12be1c044826878bec039159d6d4eafe826ef773396d"},
-    {file = "coverage-7.8.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:db181a1896e0bad75b3bf4916c49fd3cf6751f9cc203fe0e0ecbee1fc43590fa"},
-    {file = "coverage-7.8.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ce2606a171f9cf7c15a77ca61f979ffc0e0d92cd2fb18767cead58c1d19f58e"},
-    {file = "coverage-7.8.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4fc4f7cff2495d6d112353c33a439230a6de0b7cd0c2578f1e8d75326f63d783"},
-    {file = "coverage-7.8.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:ff619c58322d9d6df0a859dc76c3532d7bdbc125cb040f7cd642141446b4f654"},
-    {file = "coverage-7.8.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0d6290a466a6f3fadf6add2dd4ec11deba4e1a6e3db2dd284edd497aadf802f"},
-    {file = "coverage-7.8.1-cp313-cp313t-win32.whl", hash = "sha256:e4e893c7f7fb12271a667d5c1876710fae06d7580343afdb5f3fc4488b73209e"},
-    {file = "coverage-7.8.1-cp313-cp313t-win_amd64.whl", hash = "sha256:41d142eefbc0bb3be160a77b2c0fbec76f345387676265052e224eb6c67b7af3"},
-    {file = "coverage-7.8.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d5102e17b81158de17d4b5bc363fcffd15231a38ef3f50b8e6fa01f0c6911194"},
-    {file = "coverage-7.8.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3bd8e3753257e95e94f38c058627aba1581d51f674e3badf226283b2bdb8f8ca"},
-    {file = "coverage-7.8.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d616b5a543c7d4deffa25eb8d8ae3d0d95097f08ac8b131600bb7fbf967ea0e2"},
-    {file = "coverage-7.8.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f7a95b0dce364535a63fde0ec1b1ca36400037175d3b62ce04d85dbca5e33832"},
-    {file = "coverage-7.8.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f82c1a1c1897d2293cb6c50f20fe8a9ea2add1a228eff479380917a1fe7bbb68"},
-    {file = "coverage-7.8.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:62a13b372b65fa6e11685df9ca924bed23bab1d0f277f9b67be7536f253aaf17"},
-    {file = "coverage-7.8.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:fe4877c24711458f7990392181be30166cc3ae72158036ecb48a73c30c99fb6f"},
-    {file = "coverage-7.8.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:ae5e557aa92565d72f6d3196e878e7cbd6a6380e02a15eafe0af781bd767c10d"},
-    {file = "coverage-7.8.1-cp39-cp39-win32.whl", hash = "sha256:87284f272746e31919302ab6211b16b41135109822c498f6e7b40a2f828e7836"},
-    {file = "coverage-7.8.1-cp39-cp39-win_amd64.whl", hash = "sha256:07fff2f2ce465fae27447432d39ce733476fbf8478de51fb4034c201e0c5da6d"},
-    {file = "coverage-7.8.1-pp39.pp310.pp311-none-any.whl", hash = "sha256:adafe9d71a940927dd3ad8d487f521f11277f133568b7da622666ebd08923191"},
-    {file = "coverage-7.8.1-py3-none-any.whl", hash = "sha256:e54b80885b0e61d346accc5709daf8762471a452345521cc9281604a907162c2"},
-    {file = "coverage-7.8.1.tar.gz", hash = "sha256:d41d4da5f2871b1782c6b74948d2d37aac3a5b39b43a6ba31d736b97a02ae1f1"},
+    {file = "coverage-7.8.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bd8ec21e1443fd7a447881332f7ce9d35b8fbd2849e761bb290b584535636b0a"},
+    {file = "coverage-7.8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4c26c2396674816deaeae7ded0e2b42c26537280f8fe313335858ffff35019be"},
+    {file = "coverage-7.8.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1aec326ed237e5880bfe69ad41616d333712c7937bcefc1343145e972938f9b3"},
+    {file = "coverage-7.8.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5e818796f71702d7a13e50c70de2a1924f729228580bcba1607cccf32eea46e6"},
+    {file = "coverage-7.8.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:546e537d9e24efc765c9c891328f30f826e3e4808e31f5d0f87c4ba12bbd1622"},
+    {file = "coverage-7.8.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ab9b09a2349f58e73f8ebc06fac546dd623e23b063e5398343c5270072e3201c"},
+    {file = "coverage-7.8.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:fd51355ab8a372d89fb0e6a31719e825cf8df8b6724bee942fb5b92c3f016ba3"},
+    {file = "coverage-7.8.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0774df1e093acb6c9e4d58bce7f86656aeed6c132a16e2337692c12786b32404"},
+    {file = "coverage-7.8.2-cp310-cp310-win32.whl", hash = "sha256:00f2e2f2e37f47e5f54423aeefd6c32a7dbcedc033fcd3928a4f4948e8b96af7"},
+    {file = "coverage-7.8.2-cp310-cp310-win_amd64.whl", hash = "sha256:145b07bea229821d51811bf15eeab346c236d523838eda395ea969d120d13347"},
+    {file = "coverage-7.8.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b99058eef42e6a8dcd135afb068b3d53aff3921ce699e127602efff9956457a9"},
+    {file = "coverage-7.8.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5feb7f2c3e6ea94d3b877def0270dff0947b8d8c04cfa34a17be0a4dc1836879"},
+    {file = "coverage-7.8.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:670a13249b957bb9050fab12d86acef7bf8f6a879b9d1a883799276e0d4c674a"},
+    {file = "coverage-7.8.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0bdc8bf760459a4a4187b452213e04d039990211f98644c7292adf1e471162b5"},
+    {file = "coverage-7.8.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07a989c867986c2a75f158f03fdb413128aad29aca9d4dbce5fc755672d96f11"},
+    {file = "coverage-7.8.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2db10dedeb619a771ef0e2949ccba7b75e33905de959c2643a4607bef2f3fb3a"},
+    {file = "coverage-7.8.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e6ea7dba4e92926b7b5f0990634b78ea02f208d04af520c73a7c876d5a8d36cb"},
+    {file = "coverage-7.8.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ef2f22795a7aca99fc3c84393a55a53dd18ab8c93fb431004e4d8f0774150f54"},
+    {file = "coverage-7.8.2-cp311-cp311-win32.whl", hash = "sha256:641988828bc18a6368fe72355df5f1703e44411adbe49bba5644b941ce6f2e3a"},
+    {file = "coverage-7.8.2-cp311-cp311-win_amd64.whl", hash = "sha256:8ab4a51cb39dc1933ba627e0875046d150e88478dbe22ce145a68393e9652975"},
+    {file = "coverage-7.8.2-cp311-cp311-win_arm64.whl", hash = "sha256:8966a821e2083c74d88cca5b7dcccc0a3a888a596a04c0b9668a891de3a0cc53"},
+    {file = "coverage-7.8.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e2f6fe3654468d061942591aef56686131335b7a8325684eda85dacdf311356c"},
+    {file = "coverage-7.8.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:76090fab50610798cc05241bf83b603477c40ee87acd358b66196ab0ca44ffa1"},
+    {file = "coverage-7.8.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2bd0a0a5054be160777a7920b731a0570284db5142abaaf81bcbb282b8d99279"},
+    {file = "coverage-7.8.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:da23ce9a3d356d0affe9c7036030b5c8f14556bd970c9b224f9c8205505e3b99"},
+    {file = "coverage-7.8.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9392773cffeb8d7e042a7b15b82a414011e9d2b5fdbbd3f7e6a6b17d5e21b20"},
+    {file = "coverage-7.8.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:876cbfd0b09ce09d81585d266c07a32657beb3eaec896f39484b631555be0fe2"},
+    {file = "coverage-7.8.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3da9b771c98977a13fbc3830f6caa85cae6c9c83911d24cb2d218e9394259c57"},
+    {file = "coverage-7.8.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a990f6510b3292686713bfef26d0049cd63b9c7bb17e0864f133cbfd2e6167f"},
+    {file = "coverage-7.8.2-cp312-cp312-win32.whl", hash = "sha256:bf8111cddd0f2b54d34e96613e7fbdd59a673f0cf5574b61134ae75b6f5a33b8"},
+    {file = "coverage-7.8.2-cp312-cp312-win_amd64.whl", hash = "sha256:86a323a275e9e44cdf228af9b71c5030861d4d2610886ab920d9945672a81223"},
+    {file = "coverage-7.8.2-cp312-cp312-win_arm64.whl", hash = "sha256:820157de3a589e992689ffcda8639fbabb313b323d26388d02e154164c57b07f"},
+    {file = "coverage-7.8.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ea561010914ec1c26ab4188aef8b1567272ef6de096312716f90e5baa79ef8ca"},
+    {file = "coverage-7.8.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cb86337a4fcdd0e598ff2caeb513ac604d2f3da6d53df2c8e368e07ee38e277d"},
+    {file = "coverage-7.8.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a4636ddb666971345541b59899e969f3b301143dd86b0ddbb570bd591f1e85"},
+    {file = "coverage-7.8.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5040536cf9b13fb033f76bcb5e1e5cb3b57c4807fef37db9e0ed129c6a094257"},
+    {file = "coverage-7.8.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc67994df9bcd7e0150a47ef41278b9e0a0ea187caba72414b71dc590b99a108"},
+    {file = "coverage-7.8.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e6c86888fd076d9e0fe848af0a2142bf606044dc5ceee0aa9eddb56e26895a0"},
+    {file = "coverage-7.8.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:684ca9f58119b8e26bef860db33524ae0365601492e86ba0b71d513f525e7050"},
+    {file = "coverage-7.8.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8165584ddedb49204c4e18da083913bdf6a982bfb558632a79bdaadcdafd0d48"},
+    {file = "coverage-7.8.2-cp313-cp313-win32.whl", hash = "sha256:34759ee2c65362163699cc917bdb2a54114dd06d19bab860725f94ef45a3d9b7"},
+    {file = "coverage-7.8.2-cp313-cp313-win_amd64.whl", hash = "sha256:2f9bc608fbafaee40eb60a9a53dbfb90f53cc66d3d32c2849dc27cf5638a21e3"},
+    {file = "coverage-7.8.2-cp313-cp313-win_arm64.whl", hash = "sha256:9fe449ee461a3b0c7105690419d0b0aba1232f4ff6d120a9e241e58a556733f7"},
+    {file = "coverage-7.8.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8369a7c8ef66bded2b6484053749ff220dbf83cba84f3398c84c51a6f748a008"},
+    {file = "coverage-7.8.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:159b81df53a5fcbc7d45dae3adad554fdbde9829a994e15227b3f9d816d00b36"},
+    {file = "coverage-7.8.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6fcbbd35a96192d042c691c9e0c49ef54bd7ed865846a3c9d624c30bb67ce46"},
+    {file = "coverage-7.8.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05364b9cc82f138cc86128dc4e2e1251c2981a2218bfcd556fe6b0fbaa3501be"},
+    {file = "coverage-7.8.2-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46d532db4e5ff3979ce47d18e2fe8ecad283eeb7367726da0e5ef88e4fe64740"},
+    {file = "coverage-7.8.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4000a31c34932e7e4fa0381a3d6deb43dc0c8f458e3e7ea6502e6238e10be625"},
+    {file = "coverage-7.8.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:43ff5033d657cd51f83015c3b7a443287250dc14e69910577c3e03bd2e06f27b"},
+    {file = "coverage-7.8.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94316e13f0981cbbba132c1f9f365cac1d26716aaac130866ca812006f662199"},
+    {file = "coverage-7.8.2-cp313-cp313t-win32.whl", hash = "sha256:3f5673888d3676d0a745c3d0e16da338c5eea300cb1f4ada9c872981265e76d8"},
+    {file = "coverage-7.8.2-cp313-cp313t-win_amd64.whl", hash = "sha256:2c08b05ee8d7861e45dc5a2cc4195c8c66dca5ac613144eb6ebeaff2d502e73d"},
+    {file = "coverage-7.8.2-cp313-cp313t-win_arm64.whl", hash = "sha256:1e1448bb72b387755e1ff3ef1268a06617afd94188164960dba8d0245a46004b"},
+    {file = "coverage-7.8.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:496948261eaac5ac9cf43f5d0a9f6eb7a6d4cb3bedb2c5d294138142f5c18f2a"},
+    {file = "coverage-7.8.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:eacd2de0d30871eff893bab0b67840a96445edcb3c8fd915e6b11ac4b2f3fa6d"},
+    {file = "coverage-7.8.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b039ffddc99ad65d5078ef300e0c7eed08c270dc26570440e3ef18beb816c1ca"},
+    {file = "coverage-7.8.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e49824808d4375ede9dd84e9961a59c47f9113039f1a525e6be170aa4f5c34d"},
+    {file = "coverage-7.8.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b069938961dfad881dc2f8d02b47645cd2f455d3809ba92a8a687bf513839787"},
+    {file = "coverage-7.8.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:de77c3ba8bb686d1c411e78ee1b97e6e0b963fb98b1637658dd9ad2c875cf9d7"},
+    {file = "coverage-7.8.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1676628065a498943bd3f64f099bb573e08cf1bc6088bbe33cf4424e0876f4b3"},
+    {file = "coverage-7.8.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:8e1a26e7e50076e35f7afafde570ca2b4d7900a491174ca357d29dece5aacee7"},
+    {file = "coverage-7.8.2-cp39-cp39-win32.whl", hash = "sha256:6782a12bf76fa61ad9350d5a6ef5f3f020b57f5e6305cbc663803f2ebd0f270a"},
+    {file = "coverage-7.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:1efa4166ba75ccefd647f2d78b64f53f14fb82622bc94c5a5cb0a622f50f1c9e"},
+    {file = "coverage-7.8.2-pp39.pp310.pp311-none-any.whl", hash = "sha256:ec455eedf3ba0bbdf8f5a570012617eb305c63cb9f03428d39bf544cb2b94837"},
+    {file = "coverage-7.8.2-py3-none-any.whl", hash = "sha256:726f32ee3713f7359696331a18daf0c3b3a70bb0ae71141b9d3c52be7c595e32"},
+    {file = "coverage-7.8.2.tar.gz", hash = "sha256:a886d531373a1f6ff9fad2a2ba4a045b68467b779ae729ee0b3b10ac20033b27"},
 ]
 
 [package.extras]
@@ -382,49 +386,49 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "cryptography"
-version = "45.0.2"
+version = "45.0.3"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.7"
 groups = ["dev"]
 files = [
-    {file = "cryptography-45.0.2-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:61a8b1bbddd9332917485b2453d1de49f142e6334ce1d97b7916d5a85d179c84"},
-    {file = "cryptography-45.0.2-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cc31c66411e14dd70e2f384a9204a859dc25b05e1f303df0f5326691061b839"},
-    {file = "cryptography-45.0.2-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:463096533acd5097f8751115bc600b0b64620c4aafcac10c6d0041e6e68f88fe"},
-    {file = "cryptography-45.0.2-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:cdafb86eb673c3211accffbffdb3cdffa3aaafacd14819e0898d23696d18e4d3"},
-    {file = "cryptography-45.0.2-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:05c2385b1f5c89a17df19900cfb1345115a77168f5ed44bdf6fd3de1ce5cc65b"},
-    {file = "cryptography-45.0.2-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:e9e4bdcd70216b08801e267c0b563316b787f957a46e215249921f99288456f9"},
-    {file = "cryptography-45.0.2-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:b2de529027579e43b6dc1f805f467b102fb7d13c1e54c334f1403ee2b37d0059"},
-    {file = "cryptography-45.0.2-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:10d68763892a7b19c22508ab57799c4423c7c8cd61d7eee4c5a6a55a46511949"},
-    {file = "cryptography-45.0.2-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d2a90ce2f0f5b695e4785ac07c19a58244092f3c85d57db6d8eb1a2b26d2aad6"},
-    {file = "cryptography-45.0.2-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:59c0c8f043dd376bbd9d4f636223836aed50431af4c5a467ed9bf61520294627"},
-    {file = "cryptography-45.0.2-cp311-abi3-win32.whl", hash = "sha256:80303ee6a02ef38c4253160446cbeb5c400c07e01d4ddbd4ff722a89b736d95a"},
-    {file = "cryptography-45.0.2-cp311-abi3-win_amd64.whl", hash = "sha256:7429936146063bd1b2cfc54f0e04016b90ee9b1c908a7bed0800049cbace70eb"},
-    {file = "cryptography-45.0.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:e86c8d54cd19a13e9081898b3c24351683fd39d726ecf8e774aaa9d8d96f5f3a"},
-    {file = "cryptography-45.0.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e328357b6bbf79928363dbf13f4635b7aac0306afb7e5ad24d21d0c5761c3253"},
-    {file = "cryptography-45.0.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49af56491473231159c98c2c26f1a8f3799a60e5cf0e872d00745b858ddac9d2"},
-    {file = "cryptography-45.0.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f169469d04a23282de9d0be349499cb6683b6ff1b68901210faacac9b0c24b7d"},
-    {file = "cryptography-45.0.2-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9cfd1399064b13043082c660ddd97a0358e41c8b0dc7b77c1243e013d305c344"},
-    {file = "cryptography-45.0.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:18f8084b7ca3ce1b8d38bdfe33c48116edf9a08b4d056ef4a96dceaa36d8d965"},
-    {file = "cryptography-45.0.2-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2cb03a944a1a412724d15a7c051d50e63a868031f26b6a312f2016965b661942"},
-    {file = "cryptography-45.0.2-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a9727a21957d3327cf6b7eb5ffc9e4b663909a25fea158e3fcbc49d4cdd7881b"},
-    {file = "cryptography-45.0.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ddb8d01aa900b741d6b7cc585a97aff787175f160ab975e21f880e89d810781a"},
-    {file = "cryptography-45.0.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c0c000c1a09f069632d8a9eb3b610ac029fcc682f1d69b758e625d6ee713f4ed"},
-    {file = "cryptography-45.0.2-cp37-abi3-win32.whl", hash = "sha256:08281de408e7eb71ba3cd5098709a356bfdf65eebd7ee7633c3610f0aa80d79b"},
-    {file = "cryptography-45.0.2-cp37-abi3-win_amd64.whl", hash = "sha256:48caa55c528617fa6db1a9c3bf2e37ccb31b73e098ac2b71408d1f2db551dde4"},
-    {file = "cryptography-45.0.2-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a8ec324711596fbf21837d3a5db543937dd84597d364769b46e0102250023f77"},
-    {file = "cryptography-45.0.2-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:965611880c3fa8e504b7458484c0697e00ae6e937279cd6734fdaa2bc954dc49"},
-    {file = "cryptography-45.0.2-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d891942592789fa0ab71b502550bbadb12f540d7413d7d7c4cef4b02af0f5bc6"},
-    {file = "cryptography-45.0.2-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b19f4b28dd2ef2e6d600307fee656c00825a2980c4356a7080bd758d633c3a6f"},
-    {file = "cryptography-45.0.2-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:7c73968fbb7698a4c5d6160859db560d3aac160edde89c751edd5a8bc6560c88"},
-    {file = "cryptography-45.0.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:501de1296b2041dccf2115e3c7d4947430585601b251b140970ce255c5cfb985"},
-    {file = "cryptography-45.0.2-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:1655d3a76e3dedb683c982a6c3a2cbfae2d08f47a48ec5a3d58db52b3d29ea6f"},
-    {file = "cryptography-45.0.2-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:dc7693573f16535428183de8fd27f0ca1ca37a51baa0b41dc5ed7b3d68fe80e2"},
-    {file = "cryptography-45.0.2-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:614bca7c6ed0d8ad1dce683a6289afae1f880675b4090878a0136c3da16bc693"},
-    {file = "cryptography-45.0.2-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:4142e20c29224cec63e9e32eb1e6014fb285fe39b7be66b3564ca978a3a8afe9"},
-    {file = "cryptography-45.0.2-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9a900036b42f7324df7c7ad9569eb92ba0b613cf699160dd9c2154b24fd02f8e"},
-    {file = "cryptography-45.0.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:057723b79752a142efbc609e90b0dff27b0361ccbee3bd48312d70f5cdf53b78"},
-    {file = "cryptography-45.0.2.tar.gz", hash = "sha256:d784d57b958ffd07e9e226d17272f9af0c41572557604ca7554214def32c26bf"},
+    {file = "cryptography-45.0.3-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:7573d9eebaeceeb55285205dbbb8753ac1e962af3d9640791d12b36864065e71"},
+    {file = "cryptography-45.0.3-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d377dde61c5d67eb4311eace661c3efda46c62113ff56bf05e2d679e02aebb5b"},
+    {file = "cryptography-45.0.3-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fae1e637f527750811588e4582988932c222f8251f7b7ea93739acb624e1487f"},
+    {file = "cryptography-45.0.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ca932e11218bcc9ef812aa497cdf669484870ecbcf2d99b765d6c27a86000942"},
+    {file = "cryptography-45.0.3-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:af3f92b1dc25621f5fad065288a44ac790c5798e986a34d393ab27d2b27fcff9"},
+    {file = "cryptography-45.0.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2f8f8f0b73b885ddd7f3d8c2b2234a7d3ba49002b0223f58cfde1bedd9563c56"},
+    {file = "cryptography-45.0.3-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:9cc80ce69032ffa528b5e16d217fa4d8d4bb7d6ba8659c1b4d74a1b0f4235fca"},
+    {file = "cryptography-45.0.3-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c824c9281cb628015bfc3c59335163d4ca0540d49de4582d6c2637312907e4b1"},
+    {file = "cryptography-45.0.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5833bb4355cb377ebd880457663a972cd044e7f49585aee39245c0d592904578"},
+    {file = "cryptography-45.0.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bb5bf55dcb69f7067d80354d0a348368da907345a2c448b0babc4215ccd3497"},
+    {file = "cryptography-45.0.3-cp311-abi3-win32.whl", hash = "sha256:3ad69eeb92a9de9421e1f6685e85a10fbcfb75c833b42cc9bc2ba9fb00da4710"},
+    {file = "cryptography-45.0.3-cp311-abi3-win_amd64.whl", hash = "sha256:97787952246a77d77934d41b62fb1b6f3581d83f71b44796a4158d93b8f5c490"},
+    {file = "cryptography-45.0.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:c92519d242703b675ccefd0f0562eb45e74d438e001f8ab52d628e885751fb06"},
+    {file = "cryptography-45.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5edcb90da1843df85292ef3a313513766a78fbbb83f584a5a58fb001a5a9d57"},
+    {file = "cryptography-45.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38deed72285c7ed699864f964a3f4cf11ab3fb38e8d39cfcd96710cd2b5bb716"},
+    {file = "cryptography-45.0.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5555365a50efe1f486eed6ac7062c33b97ccef409f5970a0b6f205a7cfab59c8"},
+    {file = "cryptography-45.0.3-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e4253ed8f5948a3589b3caee7ad9a5bf218ffd16869c516535325fece163dcc"},
+    {file = "cryptography-45.0.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cfd84777b4b6684955ce86156cfb5e08d75e80dc2585e10d69e47f014f0a5342"},
+    {file = "cryptography-45.0.3-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:a2b56de3417fd5f48773ad8e91abaa700b678dc7fe1e0c757e1ae340779acf7b"},
+    {file = "cryptography-45.0.3-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:57a6500d459e8035e813bd8b51b671977fb149a8c95ed814989da682314d0782"},
+    {file = "cryptography-45.0.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f22af3c78abfbc7cbcdf2c55d23c3e022e1a462ee2481011d518c7fb9c9f3d65"},
+    {file = "cryptography-45.0.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:232954730c362638544758a8160c4ee1b832dc011d2c41a306ad8f7cccc5bb0b"},
+    {file = "cryptography-45.0.3-cp37-abi3-win32.whl", hash = "sha256:cb6ab89421bc90e0422aca911c69044c2912fc3debb19bb3c1bfe28ee3dff6ab"},
+    {file = "cryptography-45.0.3-cp37-abi3-win_amd64.whl", hash = "sha256:d54ae41e6bd70ea23707843021c778f151ca258081586f0cfa31d936ae43d1b2"},
+    {file = "cryptography-45.0.3-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ed43d396f42028c1f47b5fec012e9e12631266e3825e95c00e3cf94d472dac49"},
+    {file = "cryptography-45.0.3-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fed5aaca1750e46db870874c9c273cd5182a9e9deb16f06f7bdffdb5c2bde4b9"},
+    {file = "cryptography-45.0.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:00094838ecc7c6594171e8c8a9166124c1197b074cfca23645cee573910d76bc"},
+    {file = "cryptography-45.0.3-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:92d5f428c1a0439b2040435a1d6bc1b26ebf0af88b093c3628913dd464d13fa1"},
+    {file = "cryptography-45.0.3-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:ec64ee375b5aaa354b2b273c921144a660a511f9df8785e6d1c942967106438e"},
+    {file = "cryptography-45.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:71320fbefd05454ef2d457c481ba9a5b0e540f3753354fff6f780927c25d19b0"},
+    {file = "cryptography-45.0.3-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:edd6d51869beb7f0d472e902ef231a9b7689508e83880ea16ca3311a00bf5ce7"},
+    {file = "cryptography-45.0.3-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:555e5e2d3a53b4fabeca32835878b2818b3f23966a4efb0d566689777c5a12c8"},
+    {file = "cryptography-45.0.3-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:25286aacb947286620a31f78f2ed1a32cded7be5d8b729ba3fb2c988457639e4"},
+    {file = "cryptography-45.0.3-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:050ce5209d5072472971e6efbfc8ec5a8f9a841de5a4db0ebd9c2e392cb81972"},
+    {file = "cryptography-45.0.3-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:dc10ec1e9f21f33420cc05214989544727e776286c1c16697178978327b95c9c"},
+    {file = "cryptography-45.0.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:9eda14f049d7f09c2e8fb411dda17dd6b16a3c76a1de5e249188a32aeb92de19"},
+    {file = "cryptography-45.0.3.tar.gz", hash = "sha256:ec21313dd335c51d7877baf2972569f40a4291b76a0ce51391523ae358d05899"},
 ]
 
 [package.dependencies]
@@ -437,7 +441,7 @@ nox = ["nox (>=2024.4.15)", "nox[uv] (>=2024.3.2) ; python_full_version >= \"3.8
 pep8test = ["check-sdist ; python_full_version >= \"3.8.0\"", "click (>=8.0.1)", "mypy (>=1.4)", "ruff (>=0.3.6)"]
 sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi (>=2024)", "cryptography-vectors (==45.0.2)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==45.0.3)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
@@ -587,14 +591,14 @@ typing = ["typing-extensions (>=4.12.2) ; python_version < \"3.11\""]
 
 [[package]]
 name = "identify"
-version = "2.6.10"
+version = "2.6.12"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "identify-2.6.10-py2.py3-none-any.whl", hash = "sha256:5f34248f54136beed1a7ba6a6b5c4b6cf21ff495aac7c359e1ef831ae3b8ab25"},
-    {file = "identify-2.6.10.tar.gz", hash = "sha256:45e92fd704f3da71cc3880036633f48b4b7265fd4de2b57627cb157216eb7eb8"},
+    {file = "identify-2.6.12-py2.py3-none-any.whl", hash = "sha256:ad9672d5a72e0d2ff7c5c8809b62dfa60458626352fb0eb7b55e69bdc45334a2"},
+    {file = "identify-2.6.12.tar.gz", hash = "sha256:d8de45749f1efb108badef65ee8386f0f7bb19a7f26185f74de6367bffbaf0e6"},
 ]
 
 [package.extras]
@@ -659,14 +663,14 @@ files = [
 
 [[package]]
 name = "jsonschema"
-version = "4.23.0"
+version = "4.24.0"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "jsonschema-4.23.0-py3-none-any.whl", hash = "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566"},
-    {file = "jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4"},
+    {file = "jsonschema-4.24.0-py3-none-any.whl", hash = "sha256:a462455f19f5faf404a7902952b6f0e3ce868f3ee09a359b05eca6673bd8412d"},
+    {file = "jsonschema-4.24.0.tar.gz", hash = "sha256:0b4e8069eb12aedfa881333004bccaec24ecef5a8a6a4b6df142b2cc9599d196"},
 ]
 
 [package.dependencies]
@@ -788,14 +792,14 @@ pymongo = ["pymongo"]
 
 [[package]]
 name = "moto"
-version = "5.1.4"
+version = "5.1.5"
 description = "A library that allows you to easily mock out tests based on AWS infrastructure"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "moto-5.1.4-py3-none-any.whl", hash = "sha256:9a19d7a64c3f03824389cfbd478b64c82bd4d8da21b242a34259360d66cd108b"},
-    {file = "moto-5.1.4.tar.gz", hash = "sha256:b339c3514f2986ebefa465671b688bdbf51796705702214b1bad46490b68507a"},
+    {file = "moto-5.1.5-py3-none-any.whl", hash = "sha256:866ae85eb5efe11a78f991127531878fd7f49177eb4a6680f47060430eb8932d"},
+    {file = "moto-5.1.5.tar.gz", hash = "sha256:42b362ea9a16181e8e7b615ac212c294b882f020e9ae02f01230f167926df84e"},
 ]
 
 [package.dependencies]
@@ -1357,14 +1361,14 @@ testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pytest-mock"
-version = "3.14.0"
+version = "3.14.1"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
-    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+    {file = "pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0"},
+    {file = "pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e"},
 ]
 
 [package.dependencies]
@@ -1918,4 +1922,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "=3.13.*"
-content-hash = "314077ff79e7faaaf043d8a061b6651c629cf5d29026443c983dbe34b9cad009"
+content-hash = "6707af00993bb352511161032b139b48e1527ad0c9c637db5ec086514ed5a74c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ pre-commit = "^4.2.0"
 moto = {extras = ["s3", "secretsmanager", "ses"], version = "^5.1.4"}
 pytest-mock = "^3.14.0"
 mongomock = "^4.3.0"
+responses = "^0.25.7"
+pytest-responses = "^0.5.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,12 +10,10 @@ from tests.integration.helpers.file_helpers import (
     FileGenerationConfig,
     create_test_zip_file,
 )
-from tests.integration.mocks.mock_dataset_api_client import (
-    MockDatasetAPIClient,
-    MockDatasetAPIClientConfig,
-)
-
+from tests.integration.constants import dataset_api_url
 import dpypelines.pipeline.utils
+
+from tests.integration.mocks.mock_dataset_api_client import MockDatasetApi
 
 
 @pytest.fixture
@@ -119,7 +117,7 @@ def ses_mock(aws_credentials, ses_client_email_validator_mock):
 def setup_secrets(secretsmanager_mock, aws_credentials):
     """Setup mock secrets in AWS Secrets Manager."""
     secret_value = {
-        "DATASET_API_URL": "http://test-dataset-api.url",
+        "DATASET_API_URL": dataset_api_url,
         "UPLOAD_SERVICE_URL": "http://test-upload-service.url",
         "DE_SLACK_WEBHOOK": "http://test-slack-webhook.url",
         "SERVICE_TOKEN_FOR_UPLOAD": "test-service-token",
@@ -204,49 +202,11 @@ def create_zip_file_factory(aws_credentials):
 
 
 @pytest.fixture
-def mock_api_config(aws_credentials):
-    mock_get_response = MagicMock()
-    mock_get_response.status_code = 200
-    mock_get_response.text = '{"current": {"type": "static"}}'
-
-    mock_post_json_response = MagicMock()
-    mock_post_json_response.status_code = 201
-
-    mock_get_path_response = MagicMock()
-    mock_get_path_response.status_code = 200
-
-    mock_config = MockDatasetAPIClientConfig(
-        mock_get_response=mock_get_response,
-        mock_get_path_response=mock_get_path_response,
-        mock_post_json_response=mock_post_json_response,
-    )
-    return mock_config
-
-
-@pytest.fixture(scope="function")
-def mock_api_service_in_utils(mock_api_config, aws_credentials):
-    """Mock HTTP services (Dataset API and Upload Service)."""
-    with patch("dpypelines.pipeline.dataset_api.DatasetAPIClient") as mock_dataset_api:
-        instances = []
-
-        def create_client_instance(
-            dataset_api_url=None, dataset_path=None, edition_path=None
-        ):
-            client = MockDatasetAPIClient(
-                dataset_api_url=dataset_api_url,
-                dataset_path=dataset_path,
-                edition_path=edition_path,
-                config=mock_api_config,
-            )
-            instances.append(client)
-            return client
-
-        # Set the mock class to return our factory output when instantiated
-        mock_dataset_api.side_effect = create_client_instance
-        mock_dataset_api.instances = instances
-        mock_dataset_api.mock_config = mock_api_config
-        # Return the mock class itself so tests can inspect calls
-        yield mock_dataset_api
+def mock_dataset_api(aws_credentials, responses):
+    """Pytest fixture that provides a configured MockDatasetApi instance"""
+    api_mock = MockDatasetApi(responses)
+    yield api_mock
+    api_mock.remove_all_mocks()
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/constants.py
+++ b/tests/integration/constants.py
@@ -1,0 +1,3 @@
+dataset_api_url = "http://test-dataset-api.url"
+test_dataset_id = "test-dataset"
+test_edition_id = "time-series"

--- a/tests/integration/helpers/file_helpers.py
+++ b/tests/integration/helpers/file_helpers.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import json
 from pathlib import Path
 import tempfile
@@ -9,6 +8,7 @@ from tests.helpers.generators.data_file_generators import (
     generate_data_file,
     get_media_type_for_extension,
 )
+from tests.integration.constants import test_dataset_id, test_edition_id
 
 MANIFEST_FILE_NAME = "manifest.json"
 METADATA_FILE_NAME = "metadata.json"
@@ -101,6 +101,7 @@ def file_generator(file_name: str, data_dict_generator: Callable[[], dict]):
             dict_contents.pop(key)
 
         write_json_file(temp_path, dict_contents, file_name)
+        return dict_contents
 
     return create_file
 
@@ -111,6 +112,7 @@ def generate_manifest_dict():
             {"email": FILE_AUTHOR_EMAIL},
         ],
         "metadata_file": "metadata.json",
+        "use_previous_metadata": True,
     }
 
 
@@ -133,10 +135,10 @@ def generate_distribution_for_file_name(file_name: str) -> dict:
 def generate_metadata_dict(data_file_name: str) -> dict:
     distribution = generate_distribution_for_file_name(data_file_name)
     return {
-        "dataset_id": "test-dataset",
-        "edition": "time-series",
+        "dataset_id": test_dataset_id,
+        "edition": test_edition_id,
         "edition_title": "Edition title",
-        "release_date": datetime.now().isoformat(),
+        "release_date": "2025-05-01T14:01:00",
         "distributions": [distribution],
         "alerts": [{"type": "alert type", "description": "some alert"}],
         "usage_notes": [{"title": "how to use me", "note": "read"}],
@@ -177,7 +179,6 @@ def create_test_zip_file(
 ):
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
-
         if manifest_config.include:
             create_manifest(temp_path, manifest_config)
 

--- a/tests/integration/mocks/mock_dataset_api_client.py
+++ b/tests/integration/mocks/mock_dataset_api_client.py
@@ -1,50 +1,401 @@
-from unittest.mock import MagicMock
-from dpytools.http.api.dataset_api_client import DatasetAPIClient
+from datetime import datetime
+import json
+from typing import Dict, List, Optional, Any
+from tests.integration.constants import (
+    dataset_api_url,
+    test_dataset_id,
+    test_edition_id,
+)
+from responses import matchers
+
+mock_versions = [
+    {
+        "release_date": datetime.now().isoformat(),
+        "state": "published",
+        "distributions": [
+            {"title": "Test distribution", "format": "csv", "file": "data.csv"}
+        ],
+        "quality_designation": "quality",
+        "usage_notes": [{"title": "Test title", "note": "Test usage note"}],
+        "version": 1,
+    }
+]
 
 
-class MockDatasetAPIClientConfig:
-    def __init__(
-        self, mock_get_response, mock_get_path_response, mock_post_json_response
-    ):
-        self.mock_get_response = mock_get_response
-        self.mock_get_path_response = mock_get_path_response
-        self.mock_post_json_response = mock_post_json_response
+class DatasetApiUrlBuilder:
+    """Builds URLs for Dataset API endpoints"""
 
-
-def raise_for_status(mock: MagicMock):
-    if mock.status_code > 299 or mock.status_code < 200:
-        raise Exception(f"Mock error raised as mock status_code is {mock.status_code}")
-
-
-class MockDatasetAPIClient(DatasetAPIClient):
     def __init__(
         self,
-        dataset_api_url: str,
-        dataset_path: str,
-        edition_path: str,
-        config: MockDatasetAPIClientConfig,
+        base_url: str = dataset_api_url,
+        dataset_id: str = test_dataset_id,
+        edition_id: str = test_edition_id,
     ):
-        super().__init__(
-            dataset_api_url=dataset_api_url,
-            dataset_path=dataset_path,
-            edition_path=edition_path,
+        self.base_url = base_url
+        self.dataset_id = dataset_id
+        self.edition_id = edition_id
+
+    @property
+    def datasets_url(self) -> str:
+        return f"{self.base_url}/{self.dataset_id}"
+
+    @property
+    def versions_url(self) -> str:
+        return f"{self.base_url}/{self.dataset_id}/editions/{self.edition_id}/versions"
+
+    def custom_url(self, path: str) -> str:
+        return f"{self.base_url}/{path}"
+
+
+class DatasetApiResponseBuilder:
+    """Builds response bodies for Dataset API endpoints"""
+
+    @staticmethod
+    def dataset_response(
+        type: str = "static", state: str = "published"
+    ) -> Dict[str, Any]:
+        return {"current": {"type": type, "state": state}}
+
+    @staticmethod
+    def versions_response(
+        items: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        if items:
+            return {"items": items}
+
+        return {}
+
+    @staticmethod
+    def error_response(message: str, code: str = "ERROR") -> Dict[str, Any]:
+        return {"error": {"message": message, "code": code}}
+
+    @staticmethod
+    def create_headers() -> Dict[str, str]:
+        return {"Date": datetime.now().strftime("%a, %d %b %Y %H:%M:%S GMT")}
+
+
+class MockDatasetApi:
+    """Main class for managing dataset API mocks"""
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.url_builder = DatasetApiUrlBuilder()
+        self.response_builder = DatasetApiResponseBuilder()
+        self._active_mocks = {}
+
+        # Set up default mocks
+        self.setup_defaults()
+
+    def setup_defaults(
+        self,
+        mock_get_dataset: bool = True,
+        mock_get_versions: bool = True,
+        mock_post_versions: bool = True,
+    ):
+        """Set up default mocks for common scenarios"""
+        self.remove_all_mocks()
+        if mock_get_dataset:
+            self.mock_get_dataset()
+
+        if mock_get_versions:
+            self.mock_get_versions()
+
+        if mock_post_versions:
+            self.mock_post_versions()
+
+    def mock_get_dataset(
+        self,
+        is_static: bool = True,
+        state: str = "published",
+        status_code: int = 200,
+        custom_response: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Mock the dataset endpoint"""
+        mock_key = "get_dataset"
+        self._remove_existing_mock(mock_key)
+
+        if status_code == 404:
+            return self._mock_404_response(self.url_builder.datasets_url, mock_key)
+
+        if custom_response:
+            response_body = custom_response
+        else:
+            version_type = "static" if is_static else "filterable"
+            response_body = self.response_builder.dataset_response(version_type, state)
+
+        mock = self.responses.get(
+            self.url_builder.datasets_url,
+            body=json.dumps(response_body),
+            status=status_code,
+            content_type="application/json",
+            headers=self.response_builder.create_headers(),
         )
-        self.mock_config = config
-        self.get_path = MagicMock()
-        self.get_path.return_value = self.mock_config.mock_get_path_response
 
-        self.get = MagicMock()
-        self.get.return_value = self.mock_config.mock_get_response
+        self._active_mocks[mock_key] = mock
+        return mock
 
-        self.post_json = MagicMock()
-        self.post_json.return_value = self.mock_config.mock_post_json_response
+    def mock_get_versions(
+        self,
+        items: Optional[List[Dict[str, Any]]] = None,
+        status_code: int = 200,
+        custom_response: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Mock the versions endpoint"""
+        mock_key = "get_versions"
+        self._remove_existing_mock(mock_key)
 
-        for mock_response in [
-            self.post_json.return_value,
-            self.get_path.return_value,
-            self.get.return_value,
-        ]:
-            self.add_raise_for_status(mock_response)
+        if status_code == 404:
+            return self._mock_404_response(self.url_builder.datasets_url, mock_key)
 
-    def add_raise_for_status(self, mock: MagicMock):
-        mock.raise_for_status.side_effect = lambda: raise_for_status(mock)
+        if custom_response:
+            response_body = custom_response
+        else:
+            if items is None:
+                items = [mock_versions[0]]
+            response_body = self.response_builder.versions_response(items)
+
+        mock = self.responses.get(
+            self.url_builder.versions_url,
+            body=json.dumps(response_body),
+            status=status_code,
+            content_type="application/json",
+            headers=self.response_builder.create_headers(),
+        )
+
+        self._active_mocks[mock_key] = mock
+        return mock
+
+    def mock_post_versions(
+        self,
+        status_code: int = 201,
+        response_body: Optional[Dict[str, Any]] = None,
+        request_body: Optional[Dict[str, Any]] = None,
+    ):
+        mock_key = "post_versions"
+        self._remove_existing_mock(mock_key)
+
+        if status_code == 404:
+            return self._mock_404_response(self.url_builder.datasets_url, mock_key)
+
+        response_matchers = (
+            [] if request_body is None else [matchers.json_params_matcher(request_body)]
+        )
+
+        mock = self.responses.post(
+            self.url_builder.versions_url,
+            body=None if response_body is None else json.dumps(response_body),
+            status=status_code,
+            content_type="application/json",
+            headers=self.response_builder.create_headers(),
+            match=response_matchers,
+        )
+
+        self._active_mocks[mock_key] = mock
+        return mock
+
+    def mock_custom_endpoint(
+        self,
+        method: str,
+        url: str,
+        response_body: Dict[str, Any],
+        status_code: int = 200,
+        mock_key: Optional[str] = None,
+    ) -> Any:
+        """Mock any custom endpoint"""
+        if mock_key is None:
+            mock_key = f"custom_{method.lower()}_{url.split('/')[-1]}"
+
+        self._remove_existing_mock(mock_key)
+
+        method_func = getattr(self.responses, method.lower())
+        mock = method_func(
+            url,
+            body=json.dumps(response_body),
+            status=status_code,
+            content_type="application/json",
+            headers=self.response_builder.create_headers(),
+        )
+
+        self._active_mocks[mock_key] = mock
+        return mock
+
+    def mock_dataset_error(
+        self, status_code: int = 500, message: str = "Internal Server Error"
+    ):
+        """Mock dataset endpoint to return an error"""
+        error_response = self.response_builder.error_response(message)
+        return self.mock_get_dataset(
+            custom_response=error_response, status_code=status_code
+        )
+
+    def mock_get_versions_error(
+        self, status_code: int = 500, message: str = "Internal Server Error"
+    ):
+        """Mock versions endpoint to return an error"""
+        error_response = self.response_builder.error_response(message)
+        return self.mock_get_versions(
+            custom_response=error_response, status_code=status_code
+        )
+
+    def mock_empty_versions(self):
+        """Mock versions endpoint to return empty list"""
+        return self.mock_get_versions(items=[])
+
+    def mock_multiple_versions(self, count: int = 3):
+        """Mock versions endpoint with multiple versions"""
+        items = []
+        for i in range(count):
+            items.append(
+                {
+                    "release_date": f"2020-0{i + 1}-01T00:00:00.000Z",
+                    "state": "published",
+                    "version": str(i + 1),
+                }
+            )
+        return self.mock_get_versions(items=items)
+
+    def mock_draft_dataset(self):
+        """Mock dataset in draft state"""
+        return self.mock_get_dataset(state="draft")
+
+    def mock_dynamic_dataset(self):
+        """Mock dynamic dataset"""
+        return self.mock_get_dataset(is_static=False)
+
+    def get_mock(self, mock_key: str) -> Any:
+        """Get a specific mock by key"""
+        return self._active_mocks.get(mock_key)
+
+    def remove_mock(self, mock_key: str):
+        """Remove a specific mock"""
+        self._remove_existing_mock(mock_key)
+
+    def reset_all(self):
+        """Reset all mocks and set up defaults again"""
+        self.remove_all_mocks()
+        self.setup_defaults()
+
+    def _remove_existing_mock(self, mock_key: str):
+        """Remove an existing mock if it exists"""
+        if mock_key in self._active_mocks:
+            try:
+                self.responses.remove(self._active_mocks[mock_key])
+            except ValueError:
+                pass
+            del self._active_mocks[mock_key]
+
+    def remove_all_mocks(self):
+        """Clear all mocks"""
+        for mock_key in self._active_mocks:
+            self.responses.remove(self._active_mocks[mock_key])
+
+        self._active_mocks.clear()
+
+    def assert_get_dataset_called(self, times: Optional[int] = None):
+        """Assert that the dataset endpoint was called with a GET request"""
+        self._assert_url_called(self.datasets_url, times, "get")
+
+    def assert_get_versions_called(self, times: Optional[int] = None):
+        """Assert that the versions endpoint was called with a GET request"""
+        self._assert_url_called(self.versions_url, times, "get")
+
+    def assert_post_versions_called(self, times: Optional[int] = None):
+        """Assert that the versions endpoint was called with a POST request"""
+        self._assert_url_called(self.versions_url, times, "post")
+
+    def assert_url_called(
+        self, url: str, times: Optional[int] = None, method: Optional[str] = None
+    ):
+        """Assert that a specific URL was called"""
+        self._assert_url_called(url, times, method)
+
+    def assert_no_requests(self):
+        """Assert that no requests were made"""
+        assert len(self.responses.calls) == 0, (
+            f"Expected no requests, but {len(self.responses.calls)} were made"
+        )
+
+    def assert_all_requests_made(self):
+        """Assert that all expected requests were made"""
+        self.assert_get_dataset_called(times=1)
+        self.assert_get_versions_called(times=1)
+        self.assert_post_versions_called(times=1)
+
+    def get_requests(
+        self, url: Optional[str] = None, method: Optional[str] = None
+    ) -> list:
+        """Get the number of requests made to a specific URL or total"""
+        matching = [
+            call
+            for call in self.responses.calls
+            if (url is None or (url is not None and call.request.url == url))
+            and (
+                method is None or (method is not None and call.request.method == method)
+            )
+        ]
+
+        return matching
+
+    def get_all_requests(self) -> List[Any]:
+        """Get all requests that were made"""
+        return self.responses.calls
+
+    def get_requests_to_url(self, url: str) -> List[Any]:
+        """Get all requests made to a specific URL"""
+        return [call for call in self.responses.calls if call.request.url == url]
+
+    def get_dataset_requests(self) -> List[Any]:
+        """Get all requests made to the dataset endpoint"""
+        return self.get_requests_to_url(self.datasets_url)
+
+    def get_versions_requests(self) -> List[Any]:
+        """Get all requests made to the versions endpoint"""
+        return self.get_requests_to_url(self.versions_url)
+
+    def print_request_summary(self):
+        """Print a summary of all requests made (useful for debugging)"""
+        if not self.responses.calls:
+            return "No requests were made"
+
+        requests_str = f"Total requests made: {len(self.responses.calls)}"
+        for i, call in enumerate(self.responses.calls, 1):
+            requests_str += f"\n{i}. {call.request.method} {call.request.url}"
+            if hasattr(call.request, "body") and call.request.body:
+                requests_str += f"\n Body: {call.request.body}"
+
+    def _assert_url_called(
+        self,
+        url: str,
+        times: Optional[int] = None,
+        method: Optional[str] = None,
+    ):
+        """Internal method to assert URL was called"""
+        actual_calls = self.get_requests(
+            url, None if method is None else method.upper()
+        )
+
+        if times is None:
+            assert len(actual_calls), (
+                f"Expected {url} {method} to be called, but it wasn't. Requests: \n{self.print_request_summary()}"
+            )
+        else:
+            assert len(actual_calls) == times, (
+                f"Expected {url}  {method} to be called {times} times, but it was called {actual_calls} times. Requests: \n{self.print_request_summary()}"
+            )
+
+    def _mock_404_response(self, url: str, mock_key: str):
+        mock = self.responses.get(
+            self.url_builder.datasets_url,
+            status=404,
+            headers=self.response_builder.create_headers(),
+        )
+        self._active_mocks[mock_key] = mock
+        return mock
+
+    @property
+    def datasets_url(self) -> str:
+        return self.url_builder.datasets_url
+
+    @property
+    def versions_url(self) -> str:
+        return self.url_builder.versions_url

--- a/tests/integration/test_aws_s3_errors.py
+++ b/tests/integration/test_aws_s3_errors.py
@@ -7,6 +7,7 @@ from tests.integration.helpers.notification_assertion_helpers import (
 )
 from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
 from tests.integration.helpers.ses_assertion_helpers import assert_no_emails_sent
+from tests.integration.mocks.mock_dataset_api_client import MockDatasetApi
 from tests.integration.mocks.mock_s3_client import create_mock_s3_client
 from botocore.exceptions import ClientError
 
@@ -22,7 +23,7 @@ def test_s3_download_error(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -58,7 +59,7 @@ def test_s3_download_error(
     mock_s3_client.download_fileobj.assert_called()
     mock_s3_client.put_object.assert_not_called()
 
-    assert len(mock_api_service_in_utils.instances) == 0
+    mock_dataset_api.assert_no_requests()
 
     # Unexpected behaviour
     assert_no_success_and_one_failure(spy_notifier)
@@ -89,13 +90,14 @@ def test_s3_copyobject_error(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
     """
     Tests when uploading file to S3 fails
     """
+
     zip_file_object_key = zip_file_object_key_factory()
 
     error_response = {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}
@@ -121,7 +123,7 @@ def test_s3_copyobject_error(
     with pytest.raises(ClientError) as e:
         start(zip_file_object_key)
 
-    assert len(mock_api_service_in_utils.instances) == 0
+    mock_dataset_api.assert_no_requests()
 
     assert e.value.operation_name == "CopyObject"
 
@@ -162,7 +164,7 @@ def test_s3_deleteobject_error(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -194,7 +196,7 @@ def test_s3_deleteobject_error(
     with pytest.raises(ClientError) as e:
         start(zip_file_object_key)
 
-    assert len(mock_api_service_in_utils.instances) == 0
+    mock_dataset_api.assert_no_requests()
 
     assert e.value.operation_name == "DeleteObject"
 

--- a/tests/integration/test_aws_secretsmanager_errors.py
+++ b/tests/integration/test_aws_secretsmanager_errors.py
@@ -6,6 +6,8 @@ from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
 from tests.integration.helpers.ses_assertion_helpers import assert_no_emails_sent
 from botocore.exceptions import ClientError
 
+from tests.integration.mocks.mock_dataset_api_client import MockDatasetApi
+
 actual_boto_client = boto3.client
 
 
@@ -20,7 +22,7 @@ def test_secretsmanager_error(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -52,7 +54,7 @@ def test_secretsmanager_error(
 
     assert "Failed to retrieve secrets from AWS Secrets Manager" in str(e.value)
 
-    assert len(mock_api_service_in_utils.instances) == 0
+    mock_dataset_api.assert_no_requests()
 
     # Is this what it should be?
     spy_notifier.assert_called()

--- a/tests/integration/test_aws_ses_errors.py
+++ b/tests/integration/test_aws_ses_errors.py
@@ -9,6 +9,8 @@ from tests.integration.helpers.upload_service_assertion_helpers import (
 )
 from botocore.exceptions import ClientError
 
+from tests.integration.mocks.mock_dataset_api_client import MockDatasetApi
+
 actual_boto_client = boto3.client
 
 
@@ -21,7 +23,7 @@ def test_ses_sendemail_error(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -52,12 +54,7 @@ def test_ses_sendemail_error(
 
     assert e.value.operation_name == "SendEmail"
 
-    assert len(mock_api_service_in_utils.instances) == 1
-
-    mock_api_client_instance = mock_api_service_in_utils.instances[0]
-    mock_api_client_instance.get.assert_called_once()
-    mock_api_client_instance.get_path.assert_called_once()
-    mock_api_client_instance.post_json.assert_called_once()
+    mock_dataset_api.assert_all_requests_made()
 
     assert len(spy_notifier.call_args_list) == 1
     spy_notifier_instance = spy_notifier.instances[0]

--- a/tests/integration/test_data_file_errors.py
+++ b/tests/integration/test_data_file_errors.py
@@ -9,13 +9,12 @@ from tests.integration.helpers.file_helpers import (
 )
 from tests.integration.helpers.notification_assertion_helpers import (
     assert_no_success_and_one_failure,
-    assert_success_notification,
 )
 from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
 from tests.integration.helpers.ses_assertion_helpers import (
     assert_exception_email_sent,
-    assert_successful_email,
 )
+from tests.integration.mocks.mock_dataset_api_client import MockDatasetApi
 
 
 @mock_aws
@@ -25,7 +24,7 @@ def test_missing_data(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -60,7 +59,7 @@ def test_empty_data(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -93,13 +92,14 @@ def test_unsupported_filetype(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
-    """Test a successful pipeline execution with mocked AWS services."""
+    """Test that an unsupported filetype errors."""
     data_contents = {"somekey": "somevalue"}
-    data_file_name = "data.json"
+    extension = "not-a-real-file"
+    data_file_name = f"data.{extension}"
     from dpypelines.s3_folder_received import start
 
     zip_file_object_key = zip_file_object_key_factory(
@@ -109,16 +109,18 @@ def test_unsupported_filetype(
         data_file_name=data_file_name,
     )
 
-    # The following assertions are likely incorrect, but match current implementation
-    result = start(zip_file_object_key)
-    assert result
-    assert_success_notification(spy_notifier)
+    with pytest.raises(ValueError) as e:
+        start(zip_file_object_key)
+
+    assert "File format validation failed for" in str(e.value)
+    assert f"Extension {extension} is not supported" in str(e.value)
+
+    assert_no_success_and_one_failure(spy_notifier)
     s3_client = boto3.client("s3", region_name="eu-west-2")
     uploaded_file_info = S3ObjectFile(zip_file_object_key)
     uploaded_file_info.verify_file_moved(s3_client)
     uploaded_file_info.verify_s3_object_in_directory(
-        s3_client, zip_file_object_key, "processed/"
+        s3_client, zip_file_object_key, "processing/"
     )
 
-    # Not desired behaviour
-    assert_successful_email()
+    assert_exception_email_sent(str(e.value))

--- a/tests/integration/test_dataset_api_errors.py
+++ b/tests/integration/test_dataset_api_errors.py
@@ -1,6 +1,7 @@
 import boto3
 import pytest
 from moto import mock_aws
+from tests.integration.conftest import MockDatasetApi
 from tests.integration.helpers.notification_assertion_helpers import (
     assert_no_success_and_one_failure,
 )
@@ -18,7 +19,7 @@ def test_non_static_dataset(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -26,10 +27,8 @@ def test_non_static_dataset(
     Test dataset type that isn't static
     """
     # Run the pipeline with the S3 object name
-    mock_api_service_in_utils.mock_config.mock_get_response.text = (
-        '{"current": {"type": "not-static"}}'
-    )
 
+    mock_dataset_api.mock_get_dataset(is_static=False)
     from dpypelines.s3_folder_received import start
 
     zip_file_object_key = zip_file_object_key_factory()
@@ -43,13 +42,9 @@ def test_non_static_dataset(
     spy_notifier_instance.success.assert_not_called()
     spy_notifier_instance.failure.assert_not_called()
 
-    assert len(mock_api_service_in_utils.instances) == 1
-
-    mock_api_client_instance = mock_api_service_in_utils.instances[0]
-    mock_api_client_instance.get_path.assert_called_once()
-    mock_api_client_instance.get.assert_called_once()
-
-    mock_api_client_instance.post_json.assert_not_called()
+    mock_dataset_api.assert_get_versions_called(times=1)
+    mock_dataset_api.assert_get_dataset_called(times=1)
+    mock_dataset_api.assert_post_versions_called(times=0)
 
     mock_upload_service.upload_new.assert_not_called()
 
@@ -66,13 +61,13 @@ def test_non_static_dataset(
 
 
 @mock_aws
-def test_get_path_404_error(
+def test_get_versions_404_error(
     zip_file_object_key_factory,
     setup_secrets,
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -80,8 +75,7 @@ def test_get_path_404_error(
     Test 404 error retrieving dataset version from Dataset API
     """
     # Run the pipeline with the S3 object name
-    mock_api_service_in_utils.mock_config.mock_get_path_response.text = None
-    mock_api_service_in_utils.mock_config.mock_get_path_response.status_code = 404
+    mock_dataset_api.mock_get_versions(status_code=404)
 
     from dpypelines.s3_folder_received import start
 
@@ -91,12 +85,9 @@ def test_get_path_404_error(
 
     assert_no_success_and_one_failure(spy_notifier)
 
-    assert len(mock_api_service_in_utils.instances) == 1
-
-    mock_api_client_instance = mock_api_service_in_utils.instances[0]
-    mock_api_client_instance.get_path.assert_called_once()
-    mock_api_client_instance.get.assert_not_called()
-    mock_api_client_instance.post_json.assert_not_called()
+    mock_dataset_api.assert_get_versions_called(times=1)
+    mock_dataset_api.assert_get_dataset_called(times=0)
+    mock_dataset_api.assert_post_versions_called(times=0)
 
     mock_upload_service.upload_new.assert_not_called()
 
@@ -119,7 +110,7 @@ def test_post_json_error(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -127,8 +118,7 @@ def test_post_json_error(
     Test when dataset API has a non-success response when uploading the metadata
     """
     # Run the pipeline with the S3 object name
-    mock_api_service_in_utils.mock_config.mock_post_json_response.text = None
-    mock_api_service_in_utils.mock_config.mock_post_json_response.status_code = 500
+    mock_dataset_api.mock_post_versions(status_code=500)
 
     from dpypelines.s3_folder_received import start
 
@@ -137,16 +127,11 @@ def test_post_json_error(
     with pytest.raises(Exception) as e:
         start(zip_file_object_key)
 
-    assert "Mock error raised as mock" in str(e.value)
+    assert "POST failed with status code: 500" in str(e.value)
 
     assert_no_success_and_one_failure(spy_notifier)
 
-    assert len(mock_api_service_in_utils.instances) == 1
-
-    mock_api_client_instance = mock_api_service_in_utils.instances[0]
-    mock_api_client_instance.get.assert_called_once()
-    mock_api_client_instance.get_path.assert_called_once()
-    mock_api_client_instance.post_json.assert_called_once()
+    mock_dataset_api.assert_all_requests_made()
 
     mock_upload_service.upload_new.assert_not_called()
 

--- a/tests/integration/test_feature_flags.py
+++ b/tests/integration/test_feature_flags.py
@@ -8,6 +8,7 @@ from tests.integration.helpers.ses_assertion_helpers import (
 from tests.integration.helpers.upload_service_assertion_helpers import (
     validate_successful_upload_service_calls,
 )
+from tests.integration.mocks.mock_dataset_api_client import MockDatasetApi
 
 
 @mock_aws
@@ -17,7 +18,7 @@ def test_notifications_disabled(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
     monkeypatch,
@@ -34,13 +35,7 @@ def test_notifications_disabled(
     # Assertions
     assert result is True
 
-    assert len(mock_api_service_in_utils.instances) == 1
-
-    mock_api_client_instance = mock_api_service_in_utils.instances[0]
-    mock_api_client_instance.get.assert_called_once()
-    mock_api_client_instance.get_path.assert_called_once()
-    mock_api_client_instance.post_json.assert_called_once()
-
+    mock_dataset_api.assert_all_requests_made()
     spy_notifier.assert_not_called()
     spy_notifier_instance = spy_notifier.instance
     spy_notifier_instance.success.assert_not_called()
@@ -70,7 +65,7 @@ def test_emails_disabled(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
     monkeypatch,
@@ -88,12 +83,7 @@ def test_emails_disabled(
     # Assertions
     assert result is True
 
-    assert len(mock_api_service_in_utils.instances) == 1
-
-    mock_api_client_instance = mock_api_service_in_utils.instances[0]
-    mock_api_client_instance.get.assert_called_once()
-    mock_api_client_instance.get_path.assert_called_once()
-    mock_api_client_instance.post_json.assert_called_once()
+    mock_dataset_api.assert_all_requests_made()
 
     spy_notifier.assert_called_once()
     spy_notifier_instance = spy_notifier.instances[0]
@@ -124,7 +114,7 @@ def test_file_upload_disabled(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
     monkeypatch,
@@ -141,7 +131,9 @@ def test_file_upload_disabled(
     # Assertions
     assert result is None
 
-    assert len(mock_api_service_in_utils.instances) == 0
+    mock_dataset_api.assert_get_versions_called(times=1)
+    mock_dataset_api.assert_get_dataset_called(times=0)
+    mock_dataset_api.assert_post_versions_called(times=0)
 
     spy_notifier.assert_called_once()
     spy_notifier_instance = spy_notifier.instance

--- a/tests/integration/test_job_configuration_errors.py
+++ b/tests/integration/test_job_configuration_errors.py
@@ -4,6 +4,7 @@ from moto import mock_aws
 import pytest
 
 from tests.integration.helpers.ses_assertion_helpers import assert_no_emails_sent
+from tests.integration.mocks.mock_dataset_api_client import MockDatasetApi
 
 
 # Environment variables
@@ -14,7 +15,7 @@ def test_invalid_environment_variables(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
     monkeypatch,
@@ -45,7 +46,7 @@ def test_missing_secret(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
     reset_pipelines_module,
@@ -72,7 +73,7 @@ def test_missing_secret_keys(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
     reset_pipelines_module,

--- a/tests/integration/test_manifest_file_errors.py
+++ b/tests/integration/test_manifest_file_errors.py
@@ -11,6 +11,7 @@ from tests.integration.helpers.notification_assertion_helpers import (
 )
 from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
 from tests.integration.helpers.ses_assertion_helpers import assert_no_emails_sent
+from tests.integration.mocks.mock_dataset_api_client import MockDatasetApi
 
 
 @mock_aws
@@ -20,7 +21,7 @@ def test_missing_manifest(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -57,7 +58,7 @@ def test_empty_manifest(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -102,7 +103,7 @@ def test_manifest_missing_fields(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
     field_to_remove,
@@ -142,7 +143,7 @@ def test_manifest_fails_when_invalid_json(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):

--- a/tests/integration/test_metadata_file_errors.py
+++ b/tests/integration/test_metadata_file_errors.py
@@ -15,6 +15,7 @@ from tests.integration.helpers.ses_assertion_helpers import (
     assert_exception_email_sent,
     assert_successful_email,
 )
+from tests.integration.mocks.mock_dataset_api_client import MockDatasetApi
 
 
 @mock_aws
@@ -24,7 +25,7 @@ def test_missing_metadata(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -56,7 +57,7 @@ def test_empty_metadata(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -86,7 +87,6 @@ def test_empty_metadata(
 
 required_metadata_fields = [
     "dataset_id",
-    "edition_title",
     "release_date",
     "edition",
     "distributions",
@@ -101,7 +101,7 @@ def test_metadata_fails_when_missing_required_field(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
     field_to_remove,
@@ -135,6 +135,7 @@ metadata_optional_fields = [
     "quality_designation",
     "usage_notes",
     "alerts",
+    "edition_title",
 ]
 
 
@@ -146,7 +147,7 @@ def test_metadata_succeeds_when_missing_optional_field(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
     field_to_remove,
@@ -183,7 +184,7 @@ def test_metadata_fails_when_invalid_json(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):

--- a/tests/integration/test_notification_errors.py
+++ b/tests/integration/test_notification_errors.py
@@ -8,6 +8,7 @@ from tests.integration.helpers.ses_assertion_helpers import (
 from tests.integration.helpers.upload_service_assertion_helpers import (
     validate_successful_upload_service_calls,
 )
+from tests.integration.mocks.mock_dataset_api_client import MockDatasetApi
 
 
 @mock_aws
@@ -17,7 +18,7 @@ def test_slack_notification_error(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -36,12 +37,7 @@ def test_slack_notification_error(
     with pytest.raises(Exception):
         start(zip_file_object_key)
 
-    assert len(mock_api_service_in_utils.instances) == 1
-
-    mock_api_client_instance = mock_api_service_in_utils.instances[0]
-    mock_api_client_instance.get.assert_called_once()
-    mock_api_client_instance.get_path.assert_called_once()
-    mock_api_client_instance.post_json.assert_called_once()
+    mock_dataset_api.assert_all_requests_made()
 
     assert len(spy_notifier.call_args_list) == 1
     spy_notifier_instance = spy_notifier.instances[0]

--- a/tests/integration/test_s3_folder_received_success.py
+++ b/tests/integration/test_s3_folder_received_success.py
@@ -1,6 +1,11 @@
 import boto3
 from moto import mock_aws
 import pytest
+from dpypelines.pipeline.models.metadata_models import DatasetVersion
+from tests.integration.helpers.file_helpers import (
+    FileGenerationConfig,
+    generate_metadata_dict,
+)
 from tests.integration.helpers.s3_assertion_helpers import S3ObjectFile
 from tests.integration.helpers.ses_assertion_helpers import (
     assert_successful_email,
@@ -8,19 +13,23 @@ from tests.integration.helpers.ses_assertion_helpers import (
 from tests.integration.helpers.upload_service_assertion_helpers import (
     validate_successful_upload_service_calls,
 )
+from tests.integration.mocks.mock_dataset_api_client import (
+    MockDatasetApi,
+    mock_versions,
+)
 
 files_to_generate = ["csvfile.csv", "sqlite.csdb", "excel.xls", "otherexcel.xlsx"]
 
 
 @pytest.mark.parametrize("data_file_name", files_to_generate)
 @mock_aws
-def test_successful_pipeline_execution(
+def test_successful_pipeline_execution_using_existing_metadata(
     zip_file_object_key_factory,
     setup_secrets,
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
     data_file_name,
@@ -28,8 +37,23 @@ def test_successful_pipeline_execution(
     """
     Test a successful pipeline execution with mocked services.
     """
+    keys_to_remove_from_metadata = ["alerts", "quality_designation", "usage_notes"]
+    zip_file_object_key = zip_file_object_key_factory(
+        data_file_name=data_file_name,
+        metadata_config=FileGenerationConfig(
+            missing_field_keys=keys_to_remove_from_metadata
+        ),
+    )
 
-    zip_file_object_key = zip_file_object_key_factory(data_file_name=data_file_name)
+    new_metadata = generate_metadata_dict(data_file_name)
+    for key in keys_to_remove_from_metadata:
+        del new_metadata[key]
+    original_metadata = mock_versions[0]
+
+    combined_metadata = original_metadata.copy()
+    combined_metadata.update(new_metadata)
+    combined_metadata = DatasetVersion(**combined_metadata).model_dump()
+    mock_dataset_api.mock_post_versions(request_body=combined_metadata)
 
     from dpypelines.s3_folder_received import start
 
@@ -38,13 +62,66 @@ def test_successful_pipeline_execution(
     # Assertions
     assert result is True
 
-    assert len(mock_api_service_in_utils.instances) == 1
+    mock_dataset_api.assert_all_requests_made()
 
-    mock_api_client_instance = mock_api_service_in_utils.instances[0]
-    mock_api_client_instance.get.assert_called_once()
-    mock_api_client_instance.get_path.assert_called_once()
-    mock_api_client_instance.post_json.assert_called_once()
+    spy_notifier.assert_called_once()
+    spy_notifier_instance = spy_notifier.instances[0]
+    spy_notifier_instance.success.assert_called_once()
+    spy_notifier_instance.failure.assert_not_called()
 
+    mock_upload_service.upload_new.assert_called()
+
+    validate_successful_upload_service_calls(
+        mock_upload_service, data_file_name=data_file_name
+    )
+
+    # Verify S3 operations - check if processing folder exists
+    s3_client = boto3.client("s3", region_name="eu-west-2")
+    uploaded_file_info = S3ObjectFile(zip_file_object_key)
+    uploaded_file_info.verify_file_moved(s3_client)
+    uploaded_file_info.verify_s3_object_in_directory(
+        s3_client, zip_file_object_key, "processed/"
+    )
+
+    assert_successful_email()
+
+
+@pytest.mark.parametrize("data_file_name", files_to_generate)
+@mock_aws
+def test_successful_pipeline_execution_with_new_metadata(
+    zip_file_object_key_factory,
+    setup_secrets,
+    ses_mock,
+    mock_slack,
+    utils_email_validator_mock,
+    mock_dataset_api: MockDatasetApi,
+    mock_upload_service,
+    spy_notifier,
+    data_file_name,
+):
+    """
+    Test a successful pipeline execution with mocked services.
+    """
+    expected_metadata = DatasetVersion(
+        **generate_metadata_dict(data_file_name)
+    ).model_dump()
+
+    mock_dataset_api.mock_post_versions(request_body=expected_metadata)
+    zip_file_object_key = zip_file_object_key_factory(
+        data_file_name=data_file_name,
+        manifest_config=FileGenerationConfig(
+            missing_field_keys=["use_previous_metadata"]
+        ),
+    )
+
+    from dpypelines.s3_folder_received import start
+
+    result = start(zip_file_object_key)
+
+    # Assertions
+    assert result is True
+
+    mock_dataset_api.assert_all_requests_made()
     spy_notifier.assert_called_once()
     spy_notifier_instance = spy_notifier.instances[0]
     spy_notifier_instance.success.assert_called_once()

--- a/tests/integration/test_upload_service_errors.py
+++ b/tests/integration/test_upload_service_errors.py
@@ -16,6 +16,7 @@ from tests.integration.helpers.ses_assertion_helpers import (
 from tests.integration.helpers.upload_service_assertion_helpers import (
     validate_successful_upload_service_calls,
 )
+from tests.integration.mocks.mock_dataset_api_client import MockDatasetApi
 
 
 @mock_aws
@@ -25,7 +26,7 @@ def test_upload_service_request_exception(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -47,12 +48,7 @@ def test_upload_service_request_exception(
 
     assert_no_success_and_one_failure(spy_notifier)
 
-    assert len(mock_api_service_in_utils.instances) == 1
-
-    mock_api_client_instance = mock_api_service_in_utils.instances[0]
-    mock_api_client_instance.get.assert_called_once()
-    mock_api_client_instance.get_path.assert_called_once()
-    mock_api_client_instance.post_json.assert_called_once()
+    mock_dataset_api.assert_all_requests_made()
 
     mock_upload_service.upload_new.assert_called_once()
 
@@ -75,7 +71,7 @@ def test_upload_service_returns_error(
     ses_mock,
     mock_slack,
     utils_email_validator_mock,
-    mock_api_service_in_utils,
+    mock_dataset_api: MockDatasetApi,
     mock_upload_service,
     spy_notifier,
 ):
@@ -100,12 +96,7 @@ def test_upload_service_returns_error(
     spy_notifier.instances[0].failure.assert_not_called()
     # END not desired behaviour
 
-    assert len(mock_api_service_in_utils.instances) == 1
-
-    mock_api_client_instance = mock_api_service_in_utils.instances[0]
-    mock_api_client_instance.get.assert_called_once()
-    mock_api_client_instance.get_path.assert_called_once()
-    mock_api_client_instance.post_json.assert_called_once()
+    mock_dataset_api.assert_all_requests_made()
 
     validate_successful_upload_service_calls(mock_upload_service)
     # Verify S3 operations - check if processing folder exists

--- a/tests/pipelines/pipeline/metadata/test_metadata_loader.py
+++ b/tests/pipelines/pipeline/metadata/test_metadata_loader.py
@@ -1,0 +1,428 @@
+import pytest
+from unittest.mock import Mock, patch, call
+from pathlib import Path
+from dpytools.http.api.versions.dataset_versions_service import DatasetVersionsService
+from dpypelines.pipeline.models.metadata_models import (
+    Distribution,
+    Manifest,
+    Metadata,
+    MinimalMetadata,
+)
+from dpytools.stores.directory.local import LocalDirectoryStore
+from dpytools.http.api.dataset_api_service import DatasetAPIService
+from dpytools.http.api.models.version import DatasetVersion
+from dpytools.logging.logger import DpLogger
+from dpypelines.pipeline.metadata.metadata_loader import MetadataLoader
+
+
+class TestMetadataLoader:
+    @pytest.fixture
+    def mock_existing_metadata_dict(self):
+        return {
+            "dataset_id": "test-dataset",
+            "edition": "test-edition",
+            "quality_designation": "original-quality-designation",
+            "edition_title": "Original edition title",
+            "release_date": "2025-05-05",
+            "state": "published",
+        }
+
+    @pytest.fixture
+    def mock_dataset_api_latest_version(self, mock_existing_metadata_dict):
+        return DatasetVersion(**mock_existing_metadata_dict)
+
+    @pytest.fixture
+    def mock_dataset_api_service(self, mock_dataset_api_latest_version):
+        mock_dataset_api_service_cls = Mock(spec=DatasetAPIService)
+        mock_dataset_api_service_cls.versions = Mock(spec=DatasetVersionsService)
+        mock_versions_response = Mock()
+        mock_versions_response.items = [Mock(), Mock()]
+        mock_versions_response.get_latest_version.return_value = (
+            mock_dataset_api_latest_version
+        )
+
+        mock_dataset_api_service_cls.versions.get_versions.return_value = (
+            mock_versions_response
+        )
+        return mock_dataset_api_service_cls
+
+    @pytest.fixture
+    def mock_logger(self):
+        return Mock(spec=DpLogger)
+
+    @pytest.fixture
+    def metadata_loader(self, mock_dataset_api_service, mock_logger):
+        return MetadataLoader(mock_dataset_api_service, mock_logger)
+
+    @pytest.fixture
+    def mock_local_store(self):
+        store = Mock(spec=LocalDirectoryStore)
+        store.local_path = Mock()
+        store.local_path.absolute.return_value = Path("/test/path")
+        return store
+
+    @pytest.fixture
+    def mock_manifest(self):
+        manifest = Mock(spec=Manifest)
+        manifest.metadata_file = "metadata.json"
+        manifest.use_previous_metadata = False
+        return manifest
+
+    @pytest.fixture
+    def mock_manifest_with_previous_metadata(self):
+        manifest = Mock(spec=Manifest)
+        manifest.metadata_file = "metadata.json"
+        manifest.use_previous_metadata = True
+        return manifest
+
+    @pytest.fixture
+    def mock_metadata_dict(self):
+        return {
+            "dataset_id": "test-dataset",
+            "edition": "test-edition",
+            "quality_designation": "original",
+            "edition_title": "Test Dataset",
+            "release_date": "2020-01-01",
+            "distributions": [
+                {"file": "data.csv", "format": "csv", "title": "Test Data"}
+            ],
+        }
+
+    @pytest.fixture
+    def mock_distribution(self):
+        return Distribution(file="data.csv", format="csv", title="Test Data")
+
+    @pytest.fixture
+    def mock_metadata(self, mock_distribution):
+        return Metadata(
+            dataset_id="test-dataset",
+            edition="test-edition",
+            distributions=[mock_distribution],
+            release_date="2025-05-22",
+        )
+
+    def test_init(self, mock_dataset_api_service, mock_logger):
+        """Test MetadataLoader initialization."""
+        loader = MetadataLoader(mock_dataset_api_service, mock_logger)
+
+        assert loader.dataset_api_service == mock_dataset_api_service
+        assert loader.logger == mock_logger
+
+    @patch(
+        "dpypelines.pipeline.metadata.metadata_loader.validate_file_exists_and_not_empty"
+    )
+    @patch("dpypelines.pipeline.metadata.metadata_loader.read_json_file")
+    def test_load_metadata_without_previous_metadata_success(
+        self,
+        mock_read_json_file,
+        mock_validate_file,
+        metadata_loader,
+        mock_manifest,
+        mock_local_store,
+        mock_metadata_dict,
+    ):
+        """Test successful metadata loading without using previous metadata."""
+        mock_read_json_file.return_value = mock_metadata_dict
+
+        with patch.object(
+            metadata_loader, "validate_distributions"
+        ) as mock_validate_distributions:
+            result = metadata_loader.load_metadata(mock_manifest, mock_local_store)
+
+            mock_validate_file.assert_called_once_with(
+                Path("/test/path") / "metadata.json"
+            )
+            mock_read_json_file.assert_called_once_with(
+                Path("/test/path") / "metadata.json"
+            )
+            mock_validate_distributions.assert_called_once()
+
+            assert isinstance(result, Metadata)
+            assert result.dataset_id == "test-dataset"
+
+    @patch(
+        "dpypelines.pipeline.metadata.metadata_loader.validate_file_exists_and_not_empty"
+    )
+    @patch("dpypelines.pipeline.metadata.metadata_loader.read_json_file")
+    def test_load_metadata_with_previous_metadata_success(
+        self,
+        mock_read_json_file,
+        mock_validate_file,
+        metadata_loader,
+        mock_manifest_with_previous_metadata,
+        mock_local_store,
+        mock_metadata_dict,
+        mock_dataset_api_latest_version,
+    ):
+        """Test successful metadata loading using previous metadata."""
+        # Setup mocks
+        mock_read_json_file.return_value = mock_metadata_dict
+
+        with patch.object(
+            metadata_loader, "_MetadataLoader__combine_metadata"
+        ) as mock_get_combined:
+            with patch.object(
+                metadata_loader, "validate_distributions"
+            ) as mock_validate_distributions:
+                mock_combined_metadata = Mock(spec=Metadata)
+                mock_get_combined.return_value = mock_combined_metadata
+
+                result = metadata_loader.load_metadata(
+                    mock_manifest_with_previous_metadata, mock_local_store
+                )
+
+                mock_validate_file.assert_called_once()
+                mock_read_json_file.assert_called_once()
+                mock_get_combined.assert_called_once_with(
+                    mock_metadata_dict, mock_dataset_api_latest_version
+                )
+                mock_validate_distributions.assert_called_once_with(
+                    mock_combined_metadata, mock_local_store
+                )
+
+                assert result == mock_combined_metadata
+
+    @patch(
+        "dpypelines.pipeline.metadata.metadata_loader.validate_file_exists_and_not_empty"
+    )
+    @patch("dpypelines.pipeline.metadata.metadata_loader.read_json_file")
+    def test_load_metadata_from_file_success(
+        self,
+        mock_read_json_file,
+        mock_validate_file,
+        metadata_loader,
+        mock_local_store,
+        mock_metadata_dict,
+    ):
+        """Test successful metadata loading from file."""
+        mock_read_json_file.return_value = mock_metadata_dict
+
+        result = metadata_loader._MetadataLoader__load_metadata_from_file(
+            "metadata.json", mock_local_store
+        )
+
+        mock_validate_file.assert_called_once_with(Path("/test/path") / "metadata.json")
+        mock_read_json_file.assert_called_once_with(
+            Path("/test/path") / "metadata.json"
+        )
+        assert result == mock_metadata_dict
+
+    @patch(
+        "dpypelines.pipeline.metadata.metadata_loader.validate_file_exists_and_not_empty"
+    )
+    def test_load_metadata_from_file_validation_failure(
+        self, mock_validate_file, metadata_loader, mock_local_store
+    ):
+        """Test metadata loading failure when file validation fails."""
+        mock_validate_file.side_effect = ValueError("File does not exist")
+
+        with pytest.raises(ValueError, match="File does not exist"):
+            metadata_loader._MetadataLoader__load_metadata_from_file(
+                "metadata.json", mock_local_store
+            )
+
+    def test_get_combined_metadata_success(
+        self, metadata_loader, mock_metadata_dict, mock_dataset_api_latest_version
+    ):
+        """Test successful combination of metadata."""
+        result = metadata_loader._MetadataLoader__combine_metadata(
+            mock_metadata_dict, mock_dataset_api_latest_version
+        )
+
+        assert isinstance(result, Metadata)
+        assert result.edition_title == mock_metadata_dict["edition_title"]
+        assert result.quality_designation == mock_metadata_dict["quality_designation"]
+
+    def test_get_latest_version_metadata_from_api_success(
+        self, metadata_loader, mock_dataset_api_service
+    ):
+        """Test successful retrieval of latest version metadata from API."""
+        minimal_metadata = MinimalMetadata(
+            dataset_id="test-dataset",
+            edition="test-edition",
+            distributions=[],
+            release_date="2045-05-05",
+        )
+
+        mock_versions_response = Mock()
+        mock_versions_response.items = [Mock(), Mock()]
+        mock_latest_version = Mock(spec=DatasetVersion)
+        mock_versions_response.get_latest_version.return_value = mock_latest_version
+
+        mock_dataset_api_service.versions.get_versions.return_value = (
+            mock_versions_response
+        )
+
+        result = metadata_loader._MetadataLoader__get_latest_version_metadata_from_api(
+            minimal_metadata
+        )
+
+        mock_dataset_api_service.versions.get_versions.assert_called_once_with(
+            dataset_id="test-dataset", edition_id="test-edition"
+        )
+        assert result == mock_latest_version
+
+    def test_get_latest_version_metadata_from_api_no_versions(
+        self, metadata_loader, mock_dataset_api_service
+    ):
+        """Test API call when no versions exist."""
+        minimal_metadata = MinimalMetadata(
+            dataset_id="test-dataset",
+            edition="test-edition",
+            distributions=[],
+            release_date="2045-05-05",
+        )
+
+        mock_versions_response = Mock()
+        mock_versions_response.items = []
+        mock_dataset_api_service.versions.get_versions.return_value = (
+            mock_versions_response
+        )
+
+        with pytest.raises(ValueError, match="Could not find existing version"):
+            metadata_loader._MetadataLoader__get_latest_version_metadata_from_api(
+                minimal_metadata
+            )
+
+    def test_get_latest_version_metadata_from_api_no_latest_version(
+        self, metadata_loader, mock_dataset_api_service
+    ):
+        """Test API call when no latest version can be determined."""
+        minimal_metadata = MinimalMetadata(
+            dataset_id="test-dataset",
+            edition="test-edition",
+            distributions=[],
+            release_date="2045-05-05",
+        )
+
+        mock_versions_response = Mock()
+        mock_versions_response.items = [Mock()]
+        mock_versions_response.get_latest_version.return_value = None
+        mock_dataset_api_service.versions.get_versions.return_value = (
+            mock_versions_response
+        )
+
+        with pytest.raises(ValueError, match="Could not find latest version"):
+            metadata_loader._MetadataLoader__get_latest_version_metadata_from_api(
+                minimal_metadata
+            )
+
+    def test_validate_distributions_success(
+        self, metadata_loader, mock_metadata, mock_local_store, mock_logger
+    ):
+        """Test successful validation of all distributions."""
+        with patch.object(
+            metadata_loader, "validate_distribution_file"
+        ) as mock_validate_dist:
+            # Execute
+            metadata_loader.validate_distributions(mock_metadata, mock_local_store)
+
+            # Assertions
+            mock_validate_dist.assert_called_once_with(
+                mock_metadata.distributions[0], mock_local_store
+            )
+            mock_logger.info.assert_called_with("Metadata and data files validated.")
+
+    @patch(
+        "dpypelines.pipeline.metadata.metadata_loader.validate_file_exists_and_not_empty"
+    )
+    @patch("dpypelines.pipeline.metadata.metadata_loader.validate_file_format")
+    def test_validate_distribution_file_success(
+        self,
+        mock_validate_format,
+        mock_validate_exists,
+        metadata_loader,
+        mock_distribution,
+        mock_local_store,
+        mock_logger,
+    ):
+        """Test successful validation of a distribution file."""
+        mock_validation_result = Mock()
+        mock_validation_result.valid = True
+        mock_validation_result.error = None
+        mock_validation_result.format = "csv"
+        mock_validate_format.return_value = mock_validation_result
+
+        # Execute
+        metadata_loader.validate_distribution_file(mock_distribution, mock_local_store)
+
+        # Assertions
+        mock_validate_exists.assert_called_once_with(Path("/test/path") / "data.csv")
+        mock_validate_format.assert_called_once_with(Path("/test/path") / "data.csv")
+
+        expected_calls = [
+            call(f"Validating distribution file {mock_distribution.file}"),
+            call("Data file found", data={"data_file_name": mock_distribution.file}),
+            call(
+                f"Validated file format for {mock_distribution.file}",
+                data={"format": "csv"},
+            ),
+        ]
+        mock_logger.info.assert_has_calls(expected_calls)
+
+    @patch(
+        "dpypelines.pipeline.metadata.metadata_loader.validate_file_exists_and_not_empty"
+    )
+    def test_validate_distribution_file_not_exists(
+        self, mock_validate_exists, metadata_loader, mock_distribution, mock_local_store
+    ):
+        """Test validation failure when distribution file doesn't exist."""
+        error_message = "File does not exist"
+        mock_validate_exists.side_effect = ValueError(error_message)
+
+        with pytest.raises(ValueError, match=error_message):
+            metadata_loader.validate_distribution_file(
+                mock_distribution, mock_local_store
+            )
+
+    @patch(
+        "dpypelines.pipeline.metadata.metadata_loader.validate_file_exists_and_not_empty"
+    )
+    @patch("dpypelines.pipeline.metadata.metadata_loader.validate_file_format")
+    def test_validate_distribution_file_invalid_format(
+        self,
+        mock_validate_format,
+        mock_validate_exists,
+        metadata_loader,
+        mock_distribution,
+        mock_local_store,
+    ):
+        """Test validation failure when file format is invalid."""
+        mock_validation_result = Mock()
+        mock_validation_result.valid = False
+        mock_validation_result.error = "Invalid CSV format"
+        mock_validate_format.return_value = mock_validation_result
+
+        with pytest.raises(
+            ValueError,
+            match=f"File format validation failed for data.csv: {mock_validation_result.error}",
+        ):
+            metadata_loader.validate_distribution_file(
+                mock_distribution, mock_local_store
+            )
+
+    @patch(
+        "dpypelines.pipeline.metadata.metadata_loader.validate_file_exists_and_not_empty"
+    )
+    @patch("dpypelines.pipeline.metadata.metadata_loader.validate_file_format")
+    def test_validate_distribution_file_format_error(
+        self,
+        mock_validate_format,
+        mock_validate_exists,
+        metadata_loader,
+        mock_distribution,
+        mock_local_store,
+    ):
+        """Test validation failure when format validation has error even if valid=True."""
+        mock_validation_result = Mock()
+        mock_validation_result.valid = True
+        mock_validation_result.error = "Some warning error"
+        mock_validate_format.return_value = mock_validation_result
+
+        with pytest.raises(
+            ValueError,
+            match=f"File format validation failed for data.csv: {mock_validation_result.error}",
+        ):
+            metadata_loader.validate_distribution_file(
+                mock_distribution, mock_local_store
+            )

--- a/tests/pipelines/pipeline/shared/files/test_json_file_readers.py
+++ b/tests/pipelines/pipeline/shared/files/test_json_file_readers.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pytest
+from dpypelines.pipeline.shared.files.json_file_readers import read_json_file
+
+
+test_cases_base_dir = Path("tests/fixtures/test-cases")
+
+
+def test_read_json_file():
+    """
+    Tests that `read_json_file()` returns the expected dictionary if a valid JSON file is provided.
+    """
+    file_path = test_cases_base_dir / "test_manifest.json"
+    result = read_json_file(file_path)
+
+    assert isinstance(result, dict)
+    assert "metadata_file" in result
+    assert "submission_contacts" in result
+    assert "email" in result["submission_contacts"][0].keys()
+
+
+def test_read_json_file_invalid():
+    """
+    Tests that `read_json_file()` raises ValueError if the JSON file is invalid.
+    """
+    file_path = test_cases_base_dir / "invalid_json_file.json"
+    file_path.write_text("invalid json")  # Write invalid JSON content
+
+    with pytest.raises(ValueError) as e:
+        read_json_file(file_path)
+
+    assert "not valid JSON" in str(e.value)
+    assert str(file_path) in str(e.value)

--- a/tests/pipelines/pipeline/test_dataset_api.py
+++ b/tests/pipelines/pipeline/test_dataset_api.py
@@ -5,7 +5,6 @@ from requests import HTTPError
 
 from dpypelines.pipeline.dataset_api import (
     dataset_type_is_static,
-    dataset_versions_path_exists,
     upload_metadata,
     validate_and_upload_metadata,
 )
@@ -15,10 +14,9 @@ from dpypelines.pipeline.models.metadata_models import Distribution, Metadata
 
 @patch("dpypelines.pipeline.dataset_api.upload_metadata")
 @patch("dpypelines.pipeline.dataset_api.is_valid_dataset")
-@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
-@patch("dpypelines.pipeline.dataset_api.JobConfiguration")
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIService")
 def test_validate_and_upload_metadata_succeeds(
-    mock_job_config, mock_DatasetAPIClient, mock_valid_dataset, mock_upload_metadata
+    mock_dataset_api_service, mock_valid_dataset, mock_upload_metadata
 ):
     metadata = Metadata(
         edition_title="Edition title",
@@ -30,12 +28,8 @@ def test_validate_and_upload_metadata_succeeds(
         edition="edition-id",
     )
 
-    mock_job_configuration = MagicMock(name="JobConfiguration")
-    mock_job_configuration.dataset_api_url = "http://dataset-api.url"
-    mock_job_config.return_value = mock_job_configuration
-
-    mock_dataset_api_client = MagicMock(name="DatasetAPIClient")
-    mock_DatasetAPIClient.return_value = mock_dataset_api_client
+    mock_dataset_api_client = MagicMock(name="DatasetAPIService")
+    mock_dataset_api_service.return_value = mock_dataset_api_client
 
     mock_valid_dataset = MagicMock(name="is_valid_dataset")
     mock_valid_dataset.return_value = True
@@ -43,16 +37,18 @@ def test_validate_and_upload_metadata_succeeds(
     mock_upload_metadata = MagicMock(name="upload_metadata")
     mock_upload_metadata.return_value = True
 
-    metadata_uploaded = validate_and_upload_metadata(metadata)
+    metadata_uploaded = validate_and_upload_metadata(
+        metadata,
+        dataset_api_service=mock_dataset_api_client,
+    )
 
     assert metadata_uploaded
 
 
 @patch("dpypelines.pipeline.dataset_api.is_valid_dataset")
-@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
-@patch("dpypelines.pipeline.dataset_api.JobConfiguration")
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIService")
 def test_validate_and_upload_metadata_fails_invalid_dataset(
-    mock_job_config, mock_DatasetAPIClient, mock_valid_dataset
+    mock_dataset_api_service, mock_valid_dataset
 ):
     metadata = Metadata(
         edition_title="Edition title",
@@ -64,26 +60,24 @@ def test_validate_and_upload_metadata_fails_invalid_dataset(
         edition="edition-id",
     )
 
-    mock_job_configuration = MagicMock(name="JobConfiguration")
-    mock_job_configuration.dataset_api_url = "http://dataset-api.url"
-    mock_job_config.return_value = mock_job_configuration
-
-    mock_dataset_api_client = MagicMock(name="DatasetAPIClient")
-    mock_DatasetAPIClient.return_value = mock_dataset_api_client
+    mock_dataset_api_client = MagicMock(name="DatasetAPIService")
+    mock_dataset_api_service.return_value = mock_dataset_api_client
 
     mock_valid_dataset.return_value = False
 
-    metadata_uploaded = validate_and_upload_metadata(metadata)
+    metadata_uploaded = validate_and_upload_metadata(
+        metadata,
+        dataset_api_service=mock_dataset_api_client,
+    )
 
     assert not metadata_uploaded
 
 
 @patch("dpypelines.pipeline.dataset_api.upload_metadata")
 @patch("dpypelines.pipeline.dataset_api.is_valid_dataset")
-@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
-@patch("dpypelines.pipeline.dataset_api.JobConfiguration")
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIService")
 def test_validate_and_upload_metadata_fails_upload_error(
-    mock_job_config, mock_DatasetAPIClient, mock_valid_dataset, mock_upload_metadata
+    mock_dataset_api_service, mock_valid_dataset, mock_upload_metadata
 ):
     metadata = Metadata(
         edition_title="Edition title",
@@ -95,26 +89,22 @@ def test_validate_and_upload_metadata_fails_upload_error(
         edition="edition-id",
     )
 
-    mock_job_configuration = MagicMock(name="JobConfiguration")
-    mock_job_configuration.dataset_api_url = "http://dataset-api.url"
-    mock_job_config.return_value = mock_job_configuration
-
-    mock_dataset_api_client = MagicMock(name="DatasetAPIClient")
-    mock_DatasetAPIClient.return_value = mock_dataset_api_client
+    mock_dataset_api_client = MagicMock(name="DatasetAPIService")
+    mock_dataset_api_service.return_value = mock_dataset_api_client
 
     mock_valid_dataset.return_value = True
     mock_upload_metadata.return_value = False
 
-    metadata_uploaded = validate_and_upload_metadata(metadata)
+    metadata_uploaded = validate_and_upload_metadata(metadata, mock_dataset_api_client)
 
     assert not metadata_uploaded
 
 
-@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
-def test_upload_metadata_succeeds(mock_DatasetAPIClient):
-    mock_dataset_api_client = MagicMock(name="DatasetAPIClient")
-    mock_DatasetAPIClient.return_value = mock_dataset_api_client
-    mock_dataset_api_client.post_json.return_value.status_code = 200
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIService")
+def test_upload_metadata_succeeds(mock_dataset_api_service):
+    mock_dataset_api_client = MagicMock(name="DatasetAPIService")
+    mock_dataset_api_service.return_value = mock_dataset_api_client
+    mock_dataset_api_client.versions.create_version.return_value.status_code = 200
     metadata = Metadata(
         edition_title="Edition title",
         distributions=[
@@ -127,31 +117,33 @@ def test_upload_metadata_succeeds(mock_DatasetAPIClient):
     metadata_uploaded = upload_metadata(metadata, mock_dataset_api_client)
 
     assert metadata_uploaded
-    mock_dataset_api_client.post_json.assert_called_once_with(
+    mock_dataset_api_client.versions.create_version.assert_called_once_with(
         {
-            "alerts": [],
+            "edition_title": "Edition title",
             "distributions": [
                 {
-                    "download_url": "https://download.ons.gov.uk/data.csv",
-                    "file": "data.csv",
-                    "format": "csv",
-                    "media_type": "text/csv",
                     "title": "Distribution title",
+                    "format": "csv",
+                    "file": "data.csv",
+                    "download_url": "https://download.ons.gov.uk/data.csv",
+                    "media_type": "text/csv",
                 }
             ],
-            "edition_title": "Edition title",
-            "quality_designation": None,
             "release_date": "2025-01-01T00:00:00",
+            "quality_designation": None,
             "usage_notes": [],
-        }
+            "alerts": [],
+        },
+        dataset_id="dataset-id",
+        edition_id="edition-id",
     )
 
 
-@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
-def test_upload_metadata_fails_http_error(mock_DatasetAPIClient):
-    mock_dataset_api_client = MagicMock(name="DatasetAPIClient")
-    mock_DatasetAPIClient.return_value = mock_dataset_api_client
-    mock_dataset_api_client.post_json.side_effect = HTTPError
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIService")
+def test_upload_metadata_fails_http_error(mock_dataset_api_service):
+    mock_dataset_api_client = MagicMock(name="DatasetAPIService")
+    mock_dataset_api_service.return_value = mock_dataset_api_client
+    mock_dataset_api_client.versions.create_version.side_effect = HTTPError
     metadata = Metadata(
         edition_title="Edition title",
         distributions=[
@@ -165,103 +157,82 @@ def test_upload_metadata_fails_http_error(mock_DatasetAPIClient):
         upload_metadata(metadata, mock_dataset_api_client)
 
 
-@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
-def test_dataset_versions_path_exists(mock_DatasetAPIClient):
-    mock_dataset_api_client = MagicMock(name="DatasetAPIClient")
-    mock_DatasetAPIClient.return_value = mock_dataset_api_client
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIService")
+def test_dataset_type_is_static(mock_dataset_api_service):
+    mock_dataset_api_client = MagicMock(name="DatasetAPIService")
+    mock_dataset_api_service.return_value = mock_dataset_api_client
     mock_dataset_api_client.dataset_api_url = "http://dataset-api.url"
-    mock_dataset_api_client.dataset_path = "dataset_id"
-    mock_dataset_api_client.edition_path = "edition_id"
-    mock_dataset_api_client.get_path.return_value.status_code = 200
-    path_exists = dataset_versions_path_exists(mock_dataset_api_client)
-    assert path_exists
 
+    get_datasets_response = MagicMock()
+    get_datasets_response.current.type = "static"
+    mock_dataset_api_client.datasets.get_dataset.return_value = get_datasets_response
 
-@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
-def test_dataset_versions_path_does_not_exist(mock_DatasetAPIClient):
-    mock_dataset_api_client = MagicMock(name="DatasetAPIClient")
-    mock_DatasetAPIClient.return_value = mock_dataset_api_client
-    mock_dataset_api_client.dataset_api_url = "http://dataset-api.url"
-    mock_dataset_api_client.dataset_path = "dataset_id"
-    mock_dataset_api_client.edition_path = "edition_id"
-    mock_dataset_api_client.get_path.side_effect = HTTPError
-    with pytest.raises(HTTPError):
-        dataset_versions_path_exists(mock_dataset_api_client)
-
-
-@patch("dpypelines.pipeline.dataset_api.get_dataset_id_path_response")
-@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
-def test_dataset_type_is_static(mock_DatasetAPIClient, mock_dataset_id_path_response):
-    mock_dataset_api_client = MagicMock(name="DatasetAPIClient")
-    mock_DatasetAPIClient.return_value = mock_dataset_api_client
-    mock_dataset_api_client.dataset_api_url = "http://dataset-api.url"
-    mock_dataset_api_client.dataset_path = "dataset_id"
-    mock_dataset_id_path_response.return_value = {"current": {"type": "static"}}
-
-    dataset_is_static = dataset_type_is_static(mock_dataset_api_client)
+    dataset_is_static = dataset_type_is_static("dataset_id", mock_dataset_api_client)
 
     assert dataset_is_static
 
 
-@patch("dpypelines.pipeline.dataset_api.get_dataset_id_path_response")
-@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
-def test_dataset_type_is_not_static(
-    mock_DatasetAPIClient, mock_dataset_id_path_response
-):
-    mock_dataset_api_client = MagicMock(name="DatasetAPIClient")
-    mock_DatasetAPIClient.return_value = mock_dataset_api_client
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIService")
+def test_dataset_type_is_not_static(mock_dataset_api_service):
+    mock_dataset_api_client = MagicMock(name="DatasetAPIService")
+    mock_dataset_api_service.return_value = mock_dataset_api_client
     mock_dataset_api_client.dataset_api_url = "http://dataset-api.url"
-    mock_dataset_api_client.dataset_path = "dataset_id"
-    mock_dataset_id_path_response.return_value = {"current": {"type": "not-static"}}
 
-    dataset_is_static = dataset_type_is_static(mock_dataset_api_client)
+    get_datasets_response = MagicMock()
+    get_datasets_response.current.type = "not-static"
+    mock_dataset_api_client.datasets.get_dataset.return_value = get_datasets_response
+
+    dataset_is_static = dataset_type_is_static("dataset_id", mock_dataset_api_client)
 
     assert not dataset_is_static
 
 
-@patch("dpypelines.pipeline.dataset_api.get_dataset_id_path_response")
-@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
-def test_dataset_type_is_missing(mock_DatasetAPIClient, mock_dataset_id_path_response):
-    mock_dataset_api_client = MagicMock(name="DatasetAPIClient")
-    mock_DatasetAPIClient.return_value = mock_dataset_api_client
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIService")
+def test_dataset_type_is_missing(mock_dataset_api_service):
+    mock_dataset_api_client = MagicMock(name="DatasetAPIService")
+    mock_dataset_api_service.return_value = mock_dataset_api_client
     mock_dataset_api_client.dataset_api_url = "http://dataset-api.url"
     mock_dataset_api_client.dataset_path = "dataset_id"
-    mock_dataset_id_path_response.return_value = {"current": {"key": "value"}}
+
+    get_datasets_response = MagicMock()
+    get_datasets_response.current.type = None
+    get_datasets_response.next.type = None
+    mock_dataset_api_client.datasets.get_dataset.return_value = get_datasets_response
 
     with pytest.raises(DatasetTypeException) as e:
-        dataset_type_is_static(mock_dataset_api_client)
+        dataset_type_is_static("dataset_id", mock_dataset_api_client)
 
     assert "DatasetTypeException" in str(e)
 
 
-@patch("dpypelines.pipeline.dataset_api.get_dataset_id_path_response")
-@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
-def test_check_dataset_type_current_key_missing(
-    mock_DatasetAPIClient, mock_dataset_id_path_response
-):
-    mock_dataset_api_client = MagicMock(name="DatasetAPIClient")
-    mock_DatasetAPIClient.return_value = mock_dataset_api_client
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIService")
+def test_check_dataset_type_current_key_missing(mock_dataset_api_service):
+    mock_dataset_api_client = MagicMock(name="DatasetAPIService")
+    mock_dataset_api_service.return_value = mock_dataset_api_client
     mock_dataset_api_client.dataset_api_url = "http://dataset-api.url"
     mock_dataset_api_client.dataset_path = "dataset_id"
-    mock_dataset_id_path_response.return_value = {"key": {"key": "value"}}
+
+    get_datasets_response = MagicMock()
+    get_datasets_response.current = None
+    get_datasets_response.next = None
+    mock_dataset_api_client.datasets.get_dataset.return_value = get_datasets_response
 
     with pytest.raises(KeyError) as e:
-        dataset_type_is_static(mock_dataset_api_client)
+        dataset_type_is_static("dataset_id", mock_dataset_api_client)
 
     assert "'current' not found in dataset_result keys" in str(e)
 
 
-@patch("dpypelines.pipeline.dataset_api.get_dataset_id_path_response")
-@patch("dpypelines.pipeline.dataset_api.DatasetAPIClient")
-def test_check_dataset_type_404(mock_DatasetAPIClient, mock_dataset_id_path_response):
-    mock_dataset_api_client = MagicMock(name="DatasetAPIClient")
-    mock_DatasetAPIClient.return_value = mock_dataset_api_client
+@patch("dpypelines.pipeline.dataset_api.DatasetAPIService")
+def test_check_dataset_type_404(mock_dataset_api_service):
+    mock_dataset_api_client = MagicMock(name="DatasetAPIService")
+    mock_dataset_api_service.return_value = mock_dataset_api_client
     mock_dataset_api_client.dataset_api_url = "http://dataset-api.url"
     mock_dataset_api_client.dataset_path = "dataset_id"
-    mock_dataset_id_path_response.return_value = None
-    mock_dataset_api_client.get.return_value.status_code = 404
+
+    mock_dataset_api_client.datasets.get_dataset.return_value = None
 
     with pytest.raises(DatasetNotFoundException) as e:
-        dataset_type_is_static(mock_dataset_api_client)
+        dataset_type_is_static("dataset_id", mock_dataset_api_client)
 
     assert "DatasetNotFoundException" in str(e)

--- a/tests/pipelines/pipeline/test_s3_folder_received.py
+++ b/tests/pipelines/pipeline/test_s3_folder_received.py
@@ -19,21 +19,25 @@ from dpypelines.s3_folder_received import start
 @patch("dpypelines.s3_folder_received.copy_s3_processing_folder_to_destination_folder")
 @patch("dpypelines.s3_folder_received.validate_and_upload_metadata")
 @patch("dpypelines.s3_folder_received.upload_files")
-@patch("dpypelines.s3_folder_received.load_and_validate_metadata")
+@patch("dpypelines.s3_folder_received.MetadataLoader")
 @patch("dpypelines.s3_folder_received.validate_manifest")
 @patch("dpypelines.s3_folder_received.process_zip_file")
 @patch("dpypelines.s3_folder_received.setup_clients")
+@patch("dpypelines.s3_folder_received.DatasetAPIService")
 def test_start_succeeds(
+    mock_dataset_api_service,
     mock_setup_clients,
     mock_process_zip_file,
     mock_manifest_validation,
-    mock_pipeline_validation,
+    mock_metadata_loader,
     mock_upload_files,
     mock_upload_metadata,
     mock_copy_s3_processing,
     mock_delete_s3_processing,
     mock_job_config,
 ):
+    mock_dataset_api_service_instance = MagicMock()
+    mock_dataset_api_service.return_value = mock_dataset_api_service_instance
     mock_notifier, mock_email_client = (
         MagicMock(name="notifier"),
         MagicMock(name="email_client"),
@@ -49,7 +53,8 @@ def test_start_succeeds(
         metadata_file="metadata.json",
         submission_contacts=[SubmissionContact(email="test@example.org")],
     )
-    mock_pipeline_validation.return_value = Metadata(
+
+    mock_metadata = Metadata(
         dataset_id="dataset-id",
         edition="edition-id",
         edition_title="Edition title",
@@ -63,6 +68,7 @@ def test_start_succeeds(
             )
         ],
     )
+    mock_metadata_loader.return_value.load_metadata.return_value = mock_metadata
     mock_upload_metadata.return_value = True
     mock_copy_s3_processing.return_value = "processed/timestamp-files"
     mock_job_configuration = MagicMock()
@@ -79,10 +85,13 @@ def test_start_succeeds(
     mock_setup_clients.assert_called_once()
     mock_process_zip_file.assert_called_once_with("dummy_s3_object_name")
     mock_manifest_validation.assert_called_once_with(mock_local_store)
-    mock_pipeline_validation.assert_called_once_with(
+    mock_metadata_loader.return_value.load_metadata.assert_called_once_with(
         mock_manifest_validation.return_value, mock_local_store
     )
-    mock_upload_metadata.assert_called_once_with(mock_pipeline_validation.return_value)
+
+    mock_upload_metadata.assert_called_once_with(
+        metadata=mock_metadata, dataset_api_service=mock_dataset_api_service_instance
+    )
     mock_upload_files.assert_called_once_with([Path("files_dir") / "distribution.csv"])
     mock_copy_s3_processing.assert_called_once_with(
         "dummy_s3_object_name",
@@ -100,20 +109,25 @@ def test_start_succeeds(
 @patch("dpypelines.s3_folder_received.delete_s3_processing_folder")
 @patch("dpypelines.s3_folder_received.copy_s3_processing_folder_to_destination_folder")
 @patch("dpypelines.s3_folder_received.validate_and_upload_metadata")
-@patch("dpypelines.s3_folder_received.load_and_validate_metadata")
+@patch("dpypelines.s3_folder_received.MetadataLoader")
 @patch("dpypelines.s3_folder_received.validate_manifest")
 @patch("dpypelines.s3_folder_received.process_zip_file")
 @patch("dpypelines.s3_folder_received.setup_clients")
+@patch("dpypelines.s3_folder_received.DatasetAPIService")
 def test_start_fails_dataset_not_static(
+    mock_dataset_api_service,
     mock_setup_clients,
     mock_process_zip_file,
     mock_manifest_validation,
-    mock_pipeline_validation,
+    mock_metadata_loader,
     mock_upload_metadata,
     mock_copy_s3_processing,
     mock_delete_s3_processing,
     mock_job_config,
 ):
+    mock_dataset_api_service_instance = MagicMock()
+    mock_dataset_api_service.return_value = mock_dataset_api_service_instance
+
     mock_notifier, mock_email_client = (
         MagicMock(name="notifier"),
         MagicMock(name="email_client"),
@@ -129,7 +143,12 @@ def test_start_fails_dataset_not_static(
         metadata_file="metadata.json",
         submission_contacts=[SubmissionContact(email="test@example.org")],
     )
-    mock_pipeline_validation.return_value = Metadata(
+    mock_manifest_validation.return_value = Manifest(
+        metadata_file="metadata.json",
+        submission_contacts=[SubmissionContact(email="test@example.org")],
+    )
+
+    mock_metadata = Metadata(
         dataset_id="dataset-id",
         edition="edition-id",
         edition_title="Edition title",
@@ -143,6 +162,8 @@ def test_start_fails_dataset_not_static(
             )
         ],
     )
+    mock_metadata_loader.return_value.load_metadata.return_value = mock_metadata
+
     mock_upload_metadata.return_value = False
     mock_copy_s3_processing.return_value = "processed/timestamp-files"
 
@@ -160,10 +181,13 @@ def test_start_fails_dataset_not_static(
     mock_setup_clients.assert_called_once()
     mock_process_zip_file.assert_called_once_with("dummy_s3_object_name")
     mock_manifest_validation.assert_called_once_with(mock_local_store)
-    mock_pipeline_validation.assert_called_once_with(
+    mock_metadata_loader.return_value.load_metadata.assert_called_once_with(
         mock_manifest_validation.return_value, mock_local_store
     )
-    mock_upload_metadata.assert_called_once_with(mock_pipeline_validation.return_value)
+
+    mock_upload_metadata.assert_called_once_with(
+        metadata=mock_metadata, dataset_api_service=mock_dataset_api_service_instance
+    )
     mock_copy_s3_processing.assert_called_once_with(
         "dummy_s3_object_name",
         Path("files_dir"),
@@ -179,7 +203,11 @@ def test_start_fails_dataset_not_static(
 @patch("dpypelines.s3_folder_received.validate_manifest")
 @patch("dpypelines.s3_folder_received.process_zip_file")
 @patch("dpypelines.s3_folder_received.setup_clients")
+@patch("dpypelines.s3_folder_received.DatasetAPIService")
+@patch("dpypelines.s3_folder_received.JobConfiguration")
 def test_start_fails_invalid_manifest(
+    mock_job_configuration,
+    mock_dataset_api_service,
     mock_setup_clients,
     mock_process_zip_file,
     mock_manifest_validation,

--- a/tests/pipelines/pipeline/test_validate_pipeline.py
+++ b/tests/pipelines/pipeline/test_validate_pipeline.py
@@ -1,22 +1,14 @@
-import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pydantic_core import ValidationError
 
 from dpypelines.pipeline.models.metadata_models import (
     Manifest,
-    Metadata,
-    SubmissionContact,
 )
 from dpypelines.pipeline.validate_pipeline import (
     validate_manifest,
-    read_json_file,
-    validate_manifest_schema,
-    load_and_validate_metadata,
 )
-from dpypelines.pipeline.validation.models import ValidationResult
 
 test_cases_base_dir = Path("tests/fixtures/test-cases")
 
@@ -42,86 +34,3 @@ def test_validate_manifest_file_not_found(mock_local_store):
     with pytest.raises(FileNotFoundError) as e:
         validate_manifest(mock_local_store)
     assert "Failed to retrieve manifest from the local directory store." in str(e)
-
-
-@patch("dpypelines.pipeline.validate_pipeline.validate_file_exists_and_not_empty")
-@patch("dpypelines.pipeline.validate_pipeline.validate_file_format")
-@patch("dpypelines.pipeline.validate_pipeline.read_json_file")
-@patch("dpypelines.pipeline.validate_pipeline.LocalDirectoryStore")
-def test_load_and_validate_metadata(
-    mock_local_store,
-    mock_validate_json,
-    mock_file_format_validator,
-    mock_validate_file_exists_and_not_empty,
-):
-    """Test that `load_and_validate_metadata()` returns a valid Metadata model."""
-    mock_local_store = MagicMock(name="local_store")
-    mock_file_format_validator.return_value = ValidationResult(True, "csv")
-    mock_validate_file_exists_and_not_empty.return_value = None
-    manifest = Manifest(
-        metadata_file="metadata.json",
-        submission_contacts=[SubmissionContact(email="test@example.org")],
-    )
-    with open(test_cases_base_dir / "test_metadata.json", "r") as f:
-        metadata_dict = json.load(f)
-
-    mock_validate_json.return_value = metadata_dict
-
-    metadata = load_and_validate_metadata(manifest, mock_local_store)
-    assert isinstance(metadata, Metadata)
-
-
-@patch("dpypelines.pipeline.validate_pipeline.read_json_file")
-@patch("dpypelines.pipeline.validate_pipeline.LocalDirectoryStore")
-def test_load_and_validate_metadata_invalid_metadata(
-    mock_local_store, mock_validate_json
-):
-    """Test that `load_and_validate_metadata()` returns a valid Metadata model."""
-    mock_local_store = MagicMock(name="local_store")
-    manifest = Manifest(
-        metadata_file="metadata.json",
-        submission_contacts=[SubmissionContact(email="test@example.org")],
-    )
-    with open(test_cases_base_dir / "test_metadata_dataset_id_missing.json", "r") as f:
-        metadata_dict = json.load(f)
-
-    mock_validate_json.return_value = metadata_dict
-
-    with pytest.raises(ValidationError) as e:
-        load_and_validate_metadata(manifest, mock_local_store)
-
-    assert "1 validation error for Metadata\ndataset_id" in str(e)
-
-
-def test_validate_manifest_schema_fails():
-    manifest_dict = {"key": "value"}
-    with pytest.raises(ValueError) as e:
-        validate_manifest_schema(manifest_dict)
-    assert "Manifest schema validation failed" in str(e)
-
-
-def test_read_json_file():
-    """
-    Tests that `read_json_file()` returns the expected dictionary if a valid JSON file is provided.
-    """
-    file_path = test_cases_base_dir / "test_manifest.json"
-    result = read_json_file(file_path)
-
-    assert isinstance(result, dict)
-    assert "metadata_file" in result
-    assert "submission_contacts" in result
-    assert "email" in result["submission_contacts"][0].keys()
-
-
-def test_read_json_file_invalid():
-    """
-    Tests that `read_json_file()` raises ValueError if the JSON file is invalid.
-    """
-    file_path = test_cases_base_dir / "invalid_json_file.json"
-    file_path.write_text("invalid json")  # Write invalid JSON content
-
-    with pytest.raises(ValueError) as e:
-        read_json_file(file_path)
-
-    assert "not valid JSON" in str(e.value)
-    assert str(file_path) in str(e.value)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

- Update code to match Dataset API client changes in `dp-python-tools`
  - Due to changes in how the `DatasetAPIService`/`DatasetVersionsService`/`DatasetService` this has allowed moving the instantiation of the `DatasetAPIService` class to the `s3_folder_received.start` (since we no longer need the dataset not edition IDs for creating now).
      - This, in turn, means that the unit tests for the _other files_ (e.g. `validate_pipeline`) should be _smaller_ require less mocking, since now `MetadataLoader` is responsible for various things, and uses dependency injection for the various other classes it uses
  - Removed some code from `dataset_api.py`, as this has now been covered/moved to the new service(s) in `dp-python-tools`

#### Metadata

- Added field to `Manifest` to support instances where the majority of the `Metadata` for the new version will come from the previous release
- Created new `MetadataLoader` class to centralize metadata loading logic. Handles:
  - Reading metadata JSON file
  - Retrieving metadata from previous version + combining with the metadata JSON file values (if necessary) 
  - Validating distribution files (moved from `validate_pipeline.py`)

- Added `MinimalMetadata` class for reading the metadata file first, incase not all required fields exist (i.e. in instances where we have to retrieve the metadata from the last version via the Datasets API)

#### Tests

- Added `responses` and `pytest-responses`; allow better/easier mocking of `request` responses.
- Redid the mocking for the `DatasetAPIService`/`DatasetAPIClient`. Now done in one class, with various (hopefully descriptive) helper methods for assertions, changing the responses, etc.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [x] Yes
- [ ] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [ ] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

Provide links to any related issues.

### How to review

Describe the steps required to test the changes.