### PR TITLE
refactor: upload data files before metadata

### DIFF
--- a/docs/etl_processor.md
+++ b/docs/etl_processor.md
@@ -24,7 +24,7 @@ The following methods are available.
 
 ## `process_s3_object_event()`
 
-This method takes a `status_oid` argument, which is the `ObjectId` of the `Status` document to be updated with pipeline events during processing. It calls the [`get_processed_zip_file()`](#get_processed_zip_file) method to get a `ProcessedZipFile` object, and then calls [`process_metadata()`](#process_metadata) on this object.
+This method takes a `status_oid` argument, which is the `ObjectId` of the `Status` document to be updated with pipeline events during processing. It calls the [`get_processed_zip_file()`](#get_processed_zip_file) method to get a `ProcessedZipFile` object, and then calls [`process_metadata_and_distributions()`](#process_metadata_and_distributions) on this object.
 
 It returns a value of `True` if the processing is successful (including uploading the metadata to the Dataset API, and uploading the data file(s) to the Upload Service). If `SKIP_DATA_UPLOAD` is set to `True`, but all files are successfully validated, it returns `False`. In the event of a processing error, the [`__handle_exception()`](#__handle_exception) method is called.
 
@@ -54,29 +54,29 @@ processed_zip_file = etl_processor.get_processed_zip_file(status_oid=status_oid)
 #)
 ```
 
-## `process_metadata()`
+## `process_metadata_and_distributions()`
 
 This method takes `processed_zip_file` and `status_oid` arguments.
 
 <!---TODO Add links to validation.md when merged--->
-If `SKIP_DATA_UPLOAD` is set to `False`, the metadata contained in `metadata.json` is loaded and validated, and and then uploaded to the Dataset API. The [`handle_successful_metadata_upload()`](#handle_successful_metadata_upload) method is then called to validate and upload the data file(s) to the Upload Service. A value of `True` is returned if all uploads are successful.
+If `SKIP_DATA_UPLOAD` is set to `False`, the metadata contained in `metadata.json` is loaded and validated, and  the distributions listed in the metadata are uploaded to the Upload Service. The [`handle_successful_data_upload()`](#handle_successful_data_upload) method is then called to validate and upload the metadata to the Dataset API. A value of `True` is returned if all uploads are successful.
 
 If `SKIP_DATA_UPLOAD` is set to `True`, the metadata is validated, but no upload requests are made, and the method returns `False`.
 
 In the event of a pipeline error, the [`__handle_exception()`](#__handle_exception) method is called.
 
 ```python
-metadata_processed = etl_processor.process_metadata(
+metadata_processed = etl_processor.process_metadata_and_distributions(
     processed_zip_file=processed_zip_file,
     status_oid=status_oid
 )
 ```
 
-## `handle_successful_metadata_upload()`
+## `handle_successful_data_upload()`
 
-This method takes `processed_zip_file`, `metadata` and `status_oid` arguments.
+This method takes `metadata` and `status_oid` arguments.
 
-The names of the files to be uploaded are extracted from `metadata.distributions`. These files are then uploaded to the Upload Service. If the upload is successful, a confirmation email is sent to the data submitter, and a success notification is sent to the Slack channel.
+The metadata is submitted to the Dataset API as a `POST` request. If the request is successful, a confirmation email is sent to the data submitter, and a success notification is sent to the Slack channel.
 
 ```python
 metadata = MetadataLoader(
@@ -87,7 +87,6 @@ metadata = MetadataLoader(
 )
 
 handle_successful_metadata_upload(
-    processed_zip_file=processed_zip_file,
     metadata=metadata,
     status_oid=status_oid
 )

--- a/dpypelines/pipeline/etl_processor.py
+++ b/dpypelines/pipeline/etl_processor.py
@@ -42,7 +42,7 @@ class ETLProcessor:
     def __init__(self, s3_object_name: str):
         self.job_config = get_job_config()
         self.notifier, self.email_client = setup_clients(self.job_config)
-        self.logger = DpLogger("data-ingress-pipeline")
+        self.logger = DpLogger("etl-processor")
         self.dataset_api_service = self.get_dataset_api_service()
         self.upload_service_client = self.get_upload_service_client()
         self.db_datasets_service = self.get_db_datasets_service()
@@ -55,7 +55,9 @@ class ETLProcessor:
             processed_zip_file = self.get_processed_zip_file(status_oid)
             if processed_zip_file is None:
                 return False
-            return self.process_metadata(processed_zip_file, status_oid)
+            return self.process_metadata_and_distributions(
+                processed_zip_file, status_oid
+            )
         except Exception as err:
             self.__handle_exception(
                 s3_object_name=self.s3_object.name,
@@ -99,16 +101,16 @@ class ETLProcessor:
             manifest=manifest,
         )
 
-    def process_metadata(
+    def process_metadata_and_distributions(
         self, processed_zip_file: ProcessedZipFile, status_oid: ObjectId
     ) -> bool:
-        # Validate configuration and files.
+        # Load metadata
         metadata = MetadataLoader(self.dataset_api_service, self.logger).load_metadata(
             processed_zip_file.manifest, processed_zip_file.local_store
         )
 
         if self.job_config.skip_data_upload:
-            # Update datasets and statuses collections with completion event
+            # Update datasets and statuses collections with completion event if data upload skipped
             self.current_status = models.DatasetStatusType.COMPLETED
             updated_dataset = self.db_datasets_service.update_dataset_existing_status(
                 dataset_id=self.s3_object.dataset_id,
@@ -124,40 +126,7 @@ class ETLProcessor:
             )
             return False
 
-        # Upload metadata to Dataset API.
-        validate_and_upload_metadata(
-            metadata=metadata,
-            dataset_api_service=self.dataset_api_service,
-        )
-
-        # Update datasets and statuses collections with upload event (Dataset API)
-        self.current_status = models.DatasetStatusType.PROCESSING
-        updated_dataset = self.db_datasets_service.update_dataset_existing_status(
-            dataset_id=self.s3_object.dataset_id,
-            status_oid=status_oid,
-            event=DatasetEventFactory.create_uploaded_dataset_event(
-                dataset_id=self.s3_object.dataset_id,
-                event_data=DatasetEventDataFactory.create_dataset_event_data(
-                    s3_object_key=self.s3_object.key,
-                    upload_location=models.UploadLocation.DATASET_API,
-                ),
-            ),
-            new_status=self.current_status,
-        )
-        self.logger.info(
-            "Datasets collection updated",
-            data={"dataset_id": updated_dataset.dataset_id},
-        )
-        self.handle_successful_metadata_upload(processed_zip_file, metadata, status_oid)
-        return True
-
-    def handle_successful_metadata_upload(
-        self,
-        processed_zip_file: ProcessedZipFile,
-        metadata: Metadata,
-        status_oid: ObjectId,
-    ):
-        # If metadata successfully submitted, upload data files to the Upload Service
+        # Upload distributions to Upload Service
         files_to_upload = [
             processed_zip_file.decompressed_file_dir / distribution.file
             for distribution in metadata.distributions
@@ -165,7 +134,6 @@ class ETLProcessor:
         upload_files(files_to_upload, self.job_config, self.upload_service_client)
 
         # Update datasets and statuses collections with upload event (Upload Service)
-        self.current_status = models.DatasetStatusType.PROCESSING
         updated_dataset = self.db_datasets_service.update_dataset_existing_status(
             dataset_id=self.s3_object.dataset_id,
             status_oid=status_oid,
@@ -174,6 +142,38 @@ class ETLProcessor:
                 event_data=DatasetEventDataFactory.create_dataset_event_data(
                     s3_object_key=self.s3_object.key,
                     upload_location=models.UploadLocation.UPLOAD_SERVICE,
+                ),
+            ),
+            new_status=self.current_status,
+        )
+        self.logger.info(
+            "Datasets collection updated",
+            data={"dataset_id": updated_dataset.dataset_id},
+        )
+
+        self.handle_successful_data_upload(metadata, status_oid)
+        return True
+
+    def handle_successful_data_upload(
+        self,
+        metadata: Metadata,
+        status_oid: ObjectId,
+    ):
+        # Upload metadata to Dataset API.
+        validate_and_upload_metadata(
+            metadata=metadata,
+            dataset_api_service=self.dataset_api_service,
+        )
+
+        # Update datasets and statuses collections with upload event (Dataset API)
+        updated_dataset = self.db_datasets_service.update_dataset_existing_status(
+            dataset_id=self.s3_object.dataset_id,
+            status_oid=status_oid,
+            event=DatasetEventFactory.create_uploaded_dataset_event(
+                dataset_id=self.s3_object.dataset_id,
+                event_data=DatasetEventDataFactory.create_dataset_event_data(
+                    s3_object_key=self.s3_object.key,
+                    upload_location=models.UploadLocation.DATASET_API,
                 ),
             ),
             new_status=self.current_status,

--- a/tests/integration/mocks/mock_api_responses.py
+++ b/tests/integration/mocks/mock_api_responses.py
@@ -458,6 +458,11 @@ class MockAPIResponses:
         self.assert_get_versions_called(times=1)
         self.assert_post_versions_called(times=1)
 
+    def assert_no_dataset_api_requests_made(self):
+        self.assert_get_dataset_called(times=0)
+        self.assert_get_versions_called(times=0)
+        self.assert_post_versions_called(times=0)
+
     def get_requests(
         self, url: Optional[str] = None, method: Optional[str] = None
     ) -> list:

--- a/tests/integration/mocks/mock_db_operations.py
+++ b/tests/integration/mocks/mock_db_operations.py
@@ -25,6 +25,45 @@ class MockDBOperations:
         self.datasets_collection.delete_many({})
         self.statuses_collection.delete_many({})
 
+    def get_all_datasets(self):
+        return [r for r in self.datasets_collection.find({})]
+
+    def assert_no_dataset_found(self, dataset_id: str):
+        dataset = self.datasets_collection.find_one({"dataset_id": dataset_id})
+        assert dataset is None
+
+    def assert_completed_status_new_dataset(self, dataset_id: str, event_count: int):
+        dataset = self.datasets_collection.find_one({"dataset_id": dataset_id})
+        status = list(dataset["statuses"].values())[0]  # type:ignore
+        assert status["status"] == "COMPLETED"
+        assert len(status["events"]) == event_count
+
+    def assert_completed_status_existing_dataset(
+        self, dataset_id: str, event_count: int
+    ):
+        dataset = self.datasets_collection.find_one({"dataset_id": dataset_id})
+        status = list(dataset["statuses"].values())[-1]  # type:ignore
+        assert status["status"] == "COMPLETED"
+        assert len(status["events"]) == event_count
+
+    def assert_failed_status_new_dataset(
+        self, dataset_id: str, event_count: int, err_msg: str
+    ):
+        dataset = self.datasets_collection.find_one({"dataset_id": dataset_id})
+        status = list(dataset["statuses"].values())[0]  # type:ignore
+        assert status["status"] == "FAILED"
+        assert len(status["events"]) == event_count
+        assert err_msg in status["error_message"]
+
+    def assert_failed_status_existing_dataset(
+        self, dataset_id: str, event_count: int, err_msg: str
+    ):
+        dataset = self.datasets_collection.find_one({"dataset_id": dataset_id})
+        status = list(dataset["statuses"].values())[-1]  # type:ignore
+        assert status["status"] == "FAILED"
+        assert len(status["events"]) == event_count
+        assert err_msg in status["error_message"]
+
 
 def create_event(
     dataset_id: str,

--- a/tests/integration/test_aws_s3_errors.py
+++ b/tests/integration/test_aws_s3_errors.py
@@ -64,15 +64,10 @@ def test_s3_download_error(
 
     mock_api_responses.assert_no_requests()
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
-    )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert (
-        status["error_message"]
-        == "An error occurred (AccessDenied) when calling the GetObject operation: Access Denied"
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg="An error occurred (AccessDenied) when calling the GetObject operation: Access Denied",
     )
 
     # Unexpected behaviour

--- a/tests/integration/test_aws_secretsmanager_errors.py
+++ b/tests/integration/test_aws_secretsmanager_errors.py
@@ -61,11 +61,7 @@ def test_secretsmanager_error(
 
     mock_api_responses.assert_no_requests()
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
-    )
-    # Pipeline failed before first database operation
-    assert dataset is None
+    mock_db_operations.assert_no_dataset_found(dataset_id=s3_object.dataset_id)
 
     # Is this what it should be?
     spy_notifier.assert_not_called()

--- a/tests/integration/test_aws_ses_errors.py
+++ b/tests/integration/test_aws_ses_errors.py
@@ -55,12 +55,9 @@ def test_ses_sendemail_error(
 
     mock_api_responses.assert_all_requests_made()
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_completed_status_new_dataset(
+        dataset_id=s3_object.dataset_id, event_count=5
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "COMPLETED"
-    assert len(status["events"]) == 5
 
     assert len(spy_notifier.call_args_list) == 1
     spy_notifier_instance = spy_notifier.instances[0]

--- a/tests/integration/test_data_file_errors.py
+++ b/tests/integration/test_data_file_errors.py
@@ -41,13 +41,11 @@ def test_missing_data(
 
     assert DATA_FILE_NAME in str(e)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg="Required file not found: data.csv",
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert status["error_message"] == "Required file not found: data.csv"
 
     assert_no_success_and_one_failure(spy_notifier)
 
@@ -89,14 +87,11 @@ def test_empty_data(
         start(zip_file_object_key)
 
     assert "File is empty: data.csv" in str(e)
-
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg="File is empty: data.csv",
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert status["error_message"] == "File is empty: data.csv"
 
     assert_no_success_and_one_failure(spy_notifier)
 
@@ -146,15 +141,10 @@ def test_unsupported_filetype(
     assert "File format validation failed for" in str(e.value)
     assert f"Extension {extension} is not supported" in str(e.value)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
-    )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert (
-        status["error_message"]
-        == "File format validation failed for data.not-a-real-file: Extension not-a-real-file is not supported"
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg="File format validation failed for data.not-a-real-file: Extension not-a-real-file is not supported",
     )
 
     assert_no_success_and_one_failure(spy_notifier)

--- a/tests/integration/test_database_errors.py
+++ b/tests/integration/test_database_errors.py
@@ -21,14 +21,15 @@ def test_new_dataset_start_succeeds(
 
     result = start(zip_file_object_key)
 
-    all_datasets = [r for r in mock_db_operations.datasets_collection.find({})]
-    created_dataset = all_datasets[-1]
-    created_status = list(created_dataset["statuses"].values())[0]
-
     assert result
+
+    all_datasets = mock_db_operations.get_all_datasets()
+    created_dataset = all_datasets[-1]
     assert len(all_datasets) > len(mock_db_operations.datasets)
-    assert created_status["status"] == "COMPLETED"
-    assert len(created_status["events"]) == 5
+    mock_db_operations.assert_completed_status_new_dataset(
+        dataset_id=created_dataset["dataset_id"], event_count=5
+    )
+
     mock_api_responses.assert_all_requests_made()
 
 
@@ -51,17 +52,15 @@ def test_new_dataset_start_fails(
     with pytest.raises(Exception) as e:
         start(zip_file_object_key)
 
-    all_datasets = [r for r in mock_db_operations.datasets_collection.find({})]
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
-    )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-
-    assert len(all_datasets) > len(mock_db_operations.datasets)
     assert "Required file not found: data.csv" in str(e)
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert status["error_message"] == "Required file not found: data.csv"
+
+    all_datasets = mock_db_operations.get_all_datasets()
+    assert len(all_datasets) > len(mock_db_operations.datasets)
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg="Required file not found: data.csv",
+    )
 
     mock_api_responses.assert_get_versions_called(times=1)
     mock_api_responses.assert_get_dataset_called(times=0)
@@ -79,22 +78,19 @@ def test_existing_dataset_start_succeeds(
     mock_db_operations: MockDBOperations,
 ):
     zip_file_object_key, _ = zip_file_object_key_factory(dataset_id="dataset_id_1")
-    datasets_before = [r for r in mock_db_operations.datasets_collection.find({})]
+    datasets_before = mock_db_operations.get_all_datasets()
 
     from dpypelines.s3_zip_received import start
 
     result = start(zip_file_object_key)
 
-    all_datasets = [r for r in mock_db_operations.datasets_collection.find({})]
-    updated_dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": "dataset_id_1"}
-    )
-    created_status = list(updated_dataset["statuses"].values())[-1]  # type:ignore
-
     assert result
+
+    all_datasets = mock_db_operations.get_all_datasets()
     assert len(all_datasets) == len(datasets_before)
-    assert created_status["status"] == "COMPLETED"
-    assert len(created_status["events"]) == 5
+    mock_db_operations.assert_completed_status_existing_dataset(
+        dataset_id="dataset_id_1", event_count=5
+    )
 
     mock_api_responses.assert_all_requests_made()
 
@@ -124,19 +120,15 @@ def test_existing_dataset_start_fails(
     with pytest.raises(Exception) as e:
         start(zip_file_object_key)
 
-    all_datasets = [r for r in mock_db_operations.datasets_collection.find({})]
-    updated_dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": "dataset_id_1"}
-    )
-    created_status = list(updated_dataset["statuses"].values())[-1]  # type:ignore
-
     assert "File format validation failed for data" in str(e)
+
+    all_datasets = mock_db_operations.get_all_datasets()
     assert len(all_datasets) == len(mock_db_operations.datasets)
-    assert created_status["status"] == "FAILED"
-    assert len(created_status["events"]) == 3
-    assert (
-        created_status["error_message"]
-        == "File format validation failed for data.not-a-real-file: Extension not-a-real-file is not supported"
+
+    mock_db_operations.assert_failed_status_existing_dataset(
+        dataset_id="dataset_id_1",
+        event_count=3,
+        err_msg="File format validation failed for data.not-a-real-file: Extension not-a-real-file is not supported",
     )
 
     mock_api_responses.assert_get_versions_called(times=1)

--- a/tests/integration/test_dataset_api_errors.py
+++ b/tests/integration/test_dataset_api_errors.py
@@ -38,13 +38,11 @@ def test_get_versions_404_error(
 
     assert "GET failed with status code: 404" in str(e)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg="GET failed with status code: 404",
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert status["error_message"] == "GET failed with status code: 404"
 
     assert_no_success_and_one_failure(spy_notifier)
 
@@ -90,18 +88,15 @@ def test_post_json_error(
 
     assert "POST failed with status code: 500" in str(e.value)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=4,
+        err_msg="POST failed with status code: 500",
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert status["error_message"] == "POST failed with status code: 500"
 
     assert_no_success_and_one_failure(spy_notifier)
 
-    mock_api_responses.assert_all_dataset_api_requests_made()
-    mock_api_responses.assert_upload_service_called(times=0)
+    mock_api_responses.assert_all_requests_made()
 
     assert_email_sent(
         [

--- a/tests/integration/test_feature_flags.py
+++ b/tests/integration/test_feature_flags.py
@@ -36,12 +36,9 @@ def test_notifications_disabled(
 
     mock_api_responses.assert_all_requests_made()
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_completed_status_new_dataset(
+        dataset_id=s3_object.dataset_id, event_count=5
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "COMPLETED"
-    assert len(status["events"]) == 5
 
     spy_notifier.assert_not_called()
     spy_notifier_instance = spy_notifier.instance
@@ -81,12 +78,9 @@ def test_emails_disabled(
 
     mock_api_responses.assert_all_requests_made()
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_completed_status_new_dataset(
+        dataset_id=s3_object.dataset_id, event_count=5
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "COMPLETED"
-    assert len(status["events"]) == 5
 
     spy_notifier.assert_called_once()
     spy_notifier_instance = spy_notifier.instances[0]
@@ -129,15 +123,9 @@ def test_file_upload_disabled(
     mock_api_responses.assert_post_versions_called(times=0)
     mock_api_responses.assert_upload_service_called(times=0)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_completed_status_new_dataset(
+        dataset_id=s3_object.dataset_id, event_count=3
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "COMPLETED"
-    assert len(status["events"]) == 3
-    assert status["events"][-1]["event_data"]["additional_data"] == {
-        "Info": "Data upload skipped"
-    }
 
     spy_notifier.assert_called_once()
     spy_notifier_instance = spy_notifier.instance

--- a/tests/integration/test_job_configuration_errors.py
+++ b/tests/integration/test_job_configuration_errors.py
@@ -42,10 +42,7 @@ def test_invalid_environment_variables(
     assert "Input should be a valid boolean" in str(e)
     assert "DISABLE_NOTIFICATIONS" in error_string
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
-    )
-    assert dataset is None
+    mock_db_operations.assert_no_dataset_found(s3_object.dataset_id)
 
     mock_api_responses.assert_no_requests()
 
@@ -79,10 +76,7 @@ def test_missing_secret(
 
     assert "Secrets Manager can't find the specified secret" in str(e)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
-    )
-    assert dataset is None
+    mock_db_operations.assert_no_dataset_found(s3_object.dataset_id)
 
     mock_api_responses.assert_no_requests()
 
@@ -128,10 +122,7 @@ def test_missing_secret_keys(
 
     assert "1 validation error for JobConfig\nDE_SLACK_WEBHOOK" in str(e)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
-    )
-    assert dataset is None
+    mock_db_operations.assert_no_dataset_found(s3_object.dataset_id)
 
     mock_api_responses.assert_no_requests()
 

--- a/tests/integration/test_manifest_file_errors.py
+++ b/tests/integration/test_manifest_file_errors.py
@@ -41,15 +41,10 @@ def test_missing_manifest(
 
     assert "Failed to retrieve manifest from the local directory store" in str(e.value)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
-    )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert (
-        status["error_message"]
-        == "Failed to retrieve manifest from the local directory store."
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg="Failed to retrieve manifest from the local directory store.",
     )
 
     assert_no_success_and_one_failure(spy_notifier)
@@ -84,13 +79,11 @@ def test_empty_manifest(
     with pytest.raises(JSONDecodeError):
         start(zip_file_object_key)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg="Expecting value: line 1 column 1 (char 0)",
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert status["error_message"] == "Expecting value: line 1 column 1 (char 0)"
     assert_no_success_and_one_failure(spy_notifier)
 
     mock_api_responses.assert_no_requests()
@@ -136,15 +129,10 @@ def test_manifest_missing_fields(
 
     assert field_to_remove in str(e.value)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
-    )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert (
-        f"Manifest schema validation failed: \nException: Invalid manifest\nException details: '{field_to_remove}' is a required property"
-        in status["error_message"]
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg=f"Manifest schema validation failed: \nException: Invalid manifest\nException details: '{field_to_remove}' is a required property",
     )
 
     assert_no_success_and_one_failure(spy_notifier)
@@ -177,14 +165,11 @@ def test_manifest_fails_when_invalid_json(
     with pytest.raises(JSONDecodeError):
         start(zip_file_object_key)
 
-    #    Check database operations
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg="Expecting value: line 1 column 1 (char 0)",
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert status["error_message"] == "Expecting value: line 1 column 1 (char 0)"
 
     assert_no_success_and_one_failure(spy_notifier)
 

--- a/tests/integration/test_metadata_file_errors.py
+++ b/tests/integration/test_metadata_file_errors.py
@@ -42,13 +42,11 @@ def test_missing_metadata(
 
     assert METADATA_FILE_NAME in str(e)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg="Required file not found: metadata.json",
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert status["error_message"] == "Required file not found: metadata.json"
 
     assert_no_success_and_one_failure(spy_notifier)
     mock_api_responses.assert_no_requests()
@@ -79,13 +77,11 @@ def test_empty_metadata(
     assert "File is empty" in str(e)
     assert METADATA_FILE_NAME in str(e)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg=f"File is empty: {METADATA_FILE_NAME}",
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert status["error_message"] == f"File is empty: {METADATA_FILE_NAME}"
 
     assert_no_success_and_one_failure(spy_notifier)
     mock_api_responses.assert_no_requests()
@@ -136,15 +132,10 @@ def test_metadata_fails_when_missing_required_field(
 
     assert field_to_remove in str(e.value)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
-    )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert (
-        f"1 validation error for MinimalMetadata\n{field_to_remove}"
-        in status["error_message"]
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg=f"1 validation error for MinimalMetadata\n{field_to_remove}",
     )
 
     assert_no_success_and_one_failure(spy_notifier)
@@ -194,12 +185,9 @@ def test_metadata_succeeds_when_missing_optional_field(
     result = start(zip_file_object_key)
     assert result
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_completed_status_new_dataset(
+        dataset_id=s3_object.dataset_id, event_count=5
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "COMPLETED"
-    assert len(status["events"]) == 5
 
     assert len(spy_notifier.instances) == 1
     spy_notifier.instances[0].success.assert_called_once()
@@ -233,15 +221,10 @@ def test_metadata_fails_when_invalid_json(
     assert "not valid JSON" in str(e.value), str(e.value)
     assert "metadata.json" in str(e.value), str(e.value)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
-    )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 3
-    assert (
-        "not valid JSON: Expecting value: line 1 column 1 (char 0)"
-        in status["error_message"]
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg="not valid JSON: Expecting value: line 1 column 1 (char 0)",
     )
 
     assert_no_success_and_one_failure(spy_notifier)

--- a/tests/integration/test_notification_errors.py
+++ b/tests/integration/test_notification_errors.py
@@ -40,12 +40,9 @@ def test_slack_notification_error(
 
     mock_api_responses.assert_all_requests_made()
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_completed_status_new_dataset(
+        dataset_id=s3_object.dataset_id, event_count=5
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "COMPLETED"
-    assert len(status["events"]) == 5
 
     assert len(spy_notifier.call_args_list) == 1
     spy_notifier_instance = spy_notifier.instances[0]

--- a/tests/integration/test_s3_zip_received_success.py
+++ b/tests/integration/test_s3_zip_received_success.py
@@ -66,12 +66,9 @@ def test_successful_pipeline_execution_using_existing_metadata(
 
     mock_api_responses.assert_all_requests_made()
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_completed_status_new_dataset(
+        dataset_id=s3_object.dataset_id, event_count=5
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "COMPLETED"
-    assert len(status["events"]) == 5
 
     spy_notifier.assert_called_once()
     spy_notifier_instance = spy_notifier.instances[0]
@@ -120,12 +117,9 @@ def test_successful_pipeline_execution_with_new_metadata(
 
     mock_api_responses.assert_all_requests_made()
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_completed_status_new_dataset(
+        dataset_id=s3_object.dataset_id, event_count=5
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "COMPLETED"
-    assert len(status["events"]) == 5
 
     spy_notifier.assert_called_once()
     spy_notifier_instance = spy_notifier.instances[0]

--- a/tests/integration/test_upload_service_errors.py
+++ b/tests/integration/test_upload_service_errors.py
@@ -41,17 +41,16 @@ def test_upload_service_request_unsupported_filetype(
 
     assert_no_success_and_one_failure(spy_notifier)
 
-    mock_api_responses.assert_all_dataset_api_requests_made()
+    mock_api_responses.assert_get_versions_called(times=1)
+    mock_api_responses.assert_get_dataset_called(times=0)
+    mock_api_responses.assert_post_versions_called(times=0)
     mock_api_responses.assert_upload_service_called(times=0)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg="Uploading file type .txt not supported for file",
     )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 4
-    assert "Uploading file type .txt not supported for file" in status["error_message"]
-
     # Not desired behaviour
     assert_exception_email_sent(str(e.value))
 
@@ -87,17 +86,15 @@ def test_upload_service_returns_404_error(
 
     assert_no_success_and_one_failure(spy_notifier)
 
-    mock_api_responses.assert_all_requests_made()
+    mock_api_responses.assert_get_versions_called(times=1)
+    mock_api_responses.assert_get_dataset_called(times=0)
+    mock_api_responses.assert_post_versions_called(times=0)
+    mock_api_responses.assert_upload_service_called(times=1)
 
-    dataset = mock_db_operations.datasets_collection.find_one(
-        {"dataset_id": s3_object.dataset_id}
-    )
-    status = list(dataset["statuses"].values())[0]  # type:ignore
-    assert status["status"] == "FAILED"
-    assert len(status["events"]) == 4
-    assert (
-        "404 Client Error: Not Found for url: http://test-upload-service.url/upload-new"
-        in status["error_message"]
+    mock_db_operations.assert_failed_status_new_dataset(
+        dataset_id=s3_object.dataset_id,
+        event_count=3,
+        err_msg="404 Client Error: Not Found for url: http://test-upload-service.url/upload-new",
     )
 
     assert_exception_email_sent(str(e.value))

--- a/tests/pipelines/pipeline/test_etl_processor.py
+++ b/tests/pipelines/pipeline/test_etl_processor.py
@@ -318,7 +318,9 @@ def test_process_s3_object_event_validate_metadata_fails(
     etl_processor = ETLProcessor(s3_object_name)
     with pytest.raises(HTTPError) as e:
         etl_processor.process_s3_object_event(status_oid)
-    mock_upload_files.assert_not_called()
+    mock_upload_files.assert_called_once_with(
+        [], mock_job_config.return_value, mock_upload_client
+    )
     assert "HTTPError" in str(e)
 
 
@@ -381,7 +383,7 @@ def test_get_processed_zip_file_success(
 @patch("dpypelines.pipeline.etl_processor.DatasetAPIService")
 @patch("dpypelines.pipeline.etl_processor.setup_clients")
 @patch("dpypelines.pipeline.etl_processor.get_job_config")
-def test_process_metadata_success(
+def test_process_metadata_and_distributions_success(
     mock_job_config,
     mock_setup_clients,
     mock_DatasetAPIService,
@@ -412,7 +414,9 @@ def test_process_metadata_success(
     metadata = Metadata(
         dataset_id="dataset_id_1",
         edition="edition_id",
-        distributions=[],
+        distributions=[
+            Distribution(title="CSV distribution", format=".csv", file="data.csv"),
+        ],
         release_date="release_date",
     )
     mock_MetadataLoader.return_value.load_metadata.return_value = metadata
@@ -432,13 +436,18 @@ def test_process_metadata_success(
 
     status_oid = mongomock.ObjectId()
     etl_processor = ETLProcessor(s3_object_name)
-    metadata_processed = etl_processor.process_metadata(processed_zip_file, status_oid)
+    metadata_processed = etl_processor.process_metadata_and_distributions(
+        processed_zip_file, status_oid
+    )
     mock_MetadataLoader.return_value.load_metadata.assert_called_once_with(
         processed_zip_file.manifest, processed_zip_file.local_store
     )
     mock_validate_metadata.assert_called_once_with(
         metadata=metadata,
         dataset_api_service=mock_dataset_api_service,
+    )
+    mock_upload_client.upload_new.assert_called_once_with(
+        Path("files/data.csv"), "text/csv"
     )
     assert metadata_processed
 
@@ -498,7 +507,7 @@ def test_process_metadata_fails_metadata_loader(
     status_oid = mongomock.ObjectId()
     etl_processor = ETLProcessor(s3_object_name)
     with pytest.raises(ValueError) as e:
-        etl_processor.process_metadata(processed_zip_file, status_oid)
+        etl_processor.process_metadata_and_distributions(processed_zip_file, status_oid)
     assert "File is empty" in str(e)
 
 
@@ -566,11 +575,10 @@ def test_process_metadata_fails_metadata_validation(
     status_oid = mongomock.ObjectId()
     etl_processor = ETLProcessor(s3_object_name)
     with pytest.raises(DatasetNotFoundException) as e:
-        etl_processor.process_metadata(processed_zip_file, status_oid)
+        etl_processor.process_metadata_and_distributions(processed_zip_file, status_oid)
     assert "Dataset dataset_id_1 not found" in str(e)
 
 
-@patch("dpypelines.pipeline.etl_processor.upload_files")
 @patch("dpypelines.pipeline.etl_processor.DocumentDBClient")
 @patch(
     "dpypelines.pipeline.etl_processor.DatasetsServiceFactory.create_db_datasets_service"
@@ -579,15 +587,13 @@ def test_process_metadata_fails_metadata_validation(
 @patch("dpypelines.pipeline.etl_processor.DatasetAPIService")
 @patch("dpypelines.pipeline.etl_processor.setup_clients")
 @patch("dpypelines.pipeline.etl_processor.get_job_config")
-def test_handle_successful_metadata_upload_success(
+def test_handle_successful_data_upload_success(
     mock_job_config,
     mock_setup_clients,
     mock_DatasetAPIService,
     mock_UploadServiceClient,
     mock_DatasetsServiceFactory,
     mock_DocumentDBClient,
-    mock_upload_files,
-    tmp_path,
 ):
     mock_job_config.return_value.skip_data_upload = False
 
@@ -607,16 +613,7 @@ def test_handle_successful_metadata_upload_success(
     mock_DocumentDBClient.connect.return_value = mock_mongo_client
 
     s3_object_name = "bucket/input/dataset_id_1 - test.zip"
-    processed_zip_file = ProcessedZipFile(
-        S3Object(s3_object_name),
-        LocalDirectoryStore(tmp_path),
-        Path("files"),
-        Manifest(
-            metadata_file="metadata.json",
-            submission_contacts=[SubmissionContact(email="test@example.org")],
-            use_previous_metadata=False,
-        ),
-    )
+
     metadata = Metadata(
         dataset_id="dataset_id_1",
         edition="edition_id",
@@ -625,20 +622,18 @@ def test_handle_successful_metadata_upload_success(
         ],
         release_date="release_date",
     )
+
     status_oid = mongomock.ObjectId()
     etl_processor = ETLProcessor(s3_object_name)
-    etl_processor.handle_successful_metadata_upload(
-        processed_zip_file, metadata, status_oid
-    )
-    mock_upload_files.assert_called_once_with(
-        [Path("files/data.csv")], mock_job_config.return_value, mock_upload_client
-    )
+    etl_processor.handle_successful_data_upload(metadata, status_oid)
+
     mock_email_client.send.assert_called_once()
     mock_notifier.success.assert_called_once()
     assert mock_datasets_service.update_dataset_existing_status.call_count == 2
 
 
-@patch("dpypelines.pipeline.etl_processor.upload_files")
+@patch("dpypelines.pipeline.etl_processor.validate_and_upload_metadata")
+@patch("dpypelines.pipeline.etl_processor.MetadataLoader")
 @patch("dpypelines.pipeline.etl_processor.DocumentDBClient")
 @patch(
     "dpypelines.pipeline.etl_processor.DatasetsServiceFactory.create_db_datasets_service"
@@ -647,15 +642,15 @@ def test_handle_successful_metadata_upload_success(
 @patch("dpypelines.pipeline.etl_processor.DatasetAPIService")
 @patch("dpypelines.pipeline.etl_processor.setup_clients")
 @patch("dpypelines.pipeline.etl_processor.get_job_config")
-def test_handle_successful_metadata_upload_fails_upload(
+def test_handle_successful_data_upload_fails_metadata_validation(
     mock_job_config,
     mock_setup_clients,
     mock_DatasetAPIService,
     mock_UploadServiceClient,
     mock_DatasetsServiceFactory,
     mock_DocumentDBClient,
-    mock_upload_files,
-    tmp_path,
+    mock_MetadataLoader,
+    mock_validate_metadata,
 ):
     mock_job_config.return_value.skip_data_upload = False
 
@@ -674,19 +669,19 @@ def test_handle_successful_metadata_upload_fails_upload(
     mock_mongo_client = mongomock.MongoClient()
     mock_DocumentDBClient.connect.return_value = mock_mongo_client
 
-    mock_upload_files.side_effect = HTTPError
+    metadata = Metadata(
+        dataset_id="dataset_id_1",
+        edition="edition_id",
+        distributions=[],
+        release_date="release_date",
+    )
+    mock_MetadataLoader.return_value.load_metadata.return_value = metadata
+    mock_validate_metadata.side_effect = DatasetNotFoundException(
+        "dataset_id_1", "dataset_path"
+    )
 
     s3_object_name = "bucket/input/dataset_id_1 - test.zip"
-    processed_zip_file = ProcessedZipFile(
-        S3Object(s3_object_name),
-        LocalDirectoryStore(tmp_path),
-        Path("files"),
-        Manifest(
-            metadata_file="metadata.json",
-            submission_contacts=[SubmissionContact(email="test@example.org")],
-            use_previous_metadata=False,
-        ),
-    )
+
     metadata = Metadata(
         dataset_id="dataset_id_1",
         edition="edition_id",
@@ -697,8 +692,6 @@ def test_handle_successful_metadata_upload_fails_upload(
     )
     status_oid = mongomock.ObjectId()
     etl_processor = ETLProcessor(s3_object_name)
-    with pytest.raises(HTTPError) as e:
-        etl_processor.handle_successful_metadata_upload(
-            processed_zip_file, metadata, status_oid
-        )
-    assert "HTTPError" in str(e)
+    with pytest.raises(DatasetNotFoundException) as e:
+        etl_processor.handle_successful_data_upload(metadata, status_oid)
+    assert "Dataset dataset_id_1 not found" in str(e)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Switched the order of requests to the Upload Service and Dataset API, so that the metadata is not submitted until the files have been successfully uploaded. This means that the `state` of the metadata does not changed to `associated` before the data files are available.

I also added some assertion helpers to the `MockDBOperations` class for integration tests.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [x] Yes
- [ ] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

https://jira.ons.gov.uk/browse/DIS-3414

### How to review

Sanity check.